### PR TITLE
`pydata/sparse` wrappers for levels, `COO`, and `CSC/CSR` formats

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,13 +29,13 @@ jobs:
           key:
             test-${{ matrix.os }}-conda-py${{ matrix.python }}-${{ env.CACHE_NUMBER }}-${{
             hashFiles('ci/environment.yml') }}
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: finch-tensor-dev
           allow-softlinks: true
           environment-file: ci/environment.yml
           python-version: ${{ matrix.python }}
-          miniforge-variant: Miniforge
+          miniforge-version: latest
           use-only-tar-bz2: true
           use-mamba: true
       - name: Install package
@@ -43,7 +43,7 @@ jobs:
           pip install -e .[tests]
       - name: Run tests
         run: |
-          pytest tests -vv
+          pytest --pyargs finch
       - uses: codecov/codecov-action@v3
         if: always()
       - name: Publish Unit Test Results

--- a/finch/__init__.py
+++ b/finch/__init__.py
@@ -1,2 +1,6 @@
-from .tensor import Tensor
-from .tensor import fsprand
+from .tensor import (
+    Tensor, Dense, Element, Pattern, SparseList, SparseByteMap,
+    RepeatRLE, SparseVBL, SparseCOO, SparseHash,
+)
+from .tensor import fsprand, jl
+from .tensor import COO, CSC, CSR

--- a/finch/__init__.py
+++ b/finch/__init__.py
@@ -3,4 +3,4 @@ from .tensor import (
     RepeatRLE, SparseVBL, SparseCOO, SparseHash,
 )
 from .tensor import fsprand, jl
-from .tensor import COO, CSC, CSR
+from .tensor import COO, CSC, CSF, CSR

--- a/finch/tensor.py
+++ b/finch/tensor.py
@@ -1,18 +1,180 @@
+from abc import abstractmethod
+from typing import Tuple
+
+import numpy as np
+import juliacall as jc
+
 from .julia import jl
 
-class Tensor:
-    def __init__(self, data):
-        self.data = data
-    def ndim(self):
-        return jl.ndims(self.data)
-    def dtype(self):
-        return jl.eltype(self.data)
+class _Display:
+    def __repr__(self):
+        return jl.sprint(jl.show, self._obj)
+    def __str__(self):
+        return jl.sprint(jl.show, jl.MIME("text/plain"), self._obj)
+
+
+class Tensor(_Display):
+    def __init__(self, lvl=None, arr=None, jl_data=None):
+        if arr is not None and not isinstance(arr, np.ndarray):
+            raise ValueError("For now only numpy input allowed")
+
+        if lvl is not None and arr is not None and jl_data is None:
+            self._obj = jl.Tensor(lvl._obj, arr)
+        elif jl_data is not None:
+            self._obj = jl_data
+        else:
+            raise ValueError(
+                "either `lvl` and numpy `arr` should be provided or a raw julia object."
+            )
+
+    @property
+    def dtype(self) -> jc.TypeValue:
+        return jl.eltype(self._obj)
+
+    @property
+    def ndim(self) -> int:
+        return jl.ndims(self._obj)
+
+    @property
+    def shape(self) -> Tuple[int, ...]:
+        return jl.size(self._obj)
+
+    @property
+    def size(self) -> int:
+        return np.prod(self.shape)
+
     def __pos__(self):
-        return Tensor(jl.Base.broadcast(jl.seval("+"), self.data))
-    def __neg__(self):    
-        return Tensor(jl.Base.broadcast(jl.seval("-"), self.data))
+        return Tensor(jl_data=jl.Base.broadcast(jl.seval("+"), self._obj))
+
     def __add__(self, other):
-        return Tensor(jl.Base.broadcast(jl.seval("+"), self.data, other.data))
+        return Tensor(jl_data=jl.Base.broadcast(jl.seval("+"), self._obj, other._obj))
+
+    def __mul__(self, other):
+        return Tensor(jl_data=jl.Base.broadcast(jl.seval("*"), self._obj, other._obj))
+
+    def __sub__(self, other):
+        return Tensor(jl_data=jl.Base.broadcast(jl.seval("-"), self._obj, other._obj))
+
+    def __truediv__(self, other):
+        return Tensor(jl_data=jl.Base.broadcast(jl.seval("/"), self._obj, other._obj))
+
+    def todense(self) -> np.ndarray:
+        shape = jl.size(self._obj)
+
+        # create fully dense array and access `val`
+        dense_lvls = jl.Element(jl.default(self._obj))
+        for _ in shape:
+            dense_lvls = jl.Dense(dense_lvls)
+        dense_tensor = jl.Tensor(dense_lvls, self._obj).lvl
+        for _ in shape:
+            dense_tensor = dense_tensor.lvl
+
+        return np.array(dense_tensor.val).reshape(shape, order="F")
+
+
+class COO(Tensor):
+    def __init__(self, coords, data, shape, fill_value=0.0):
+        assert coords.ndim == 2
+        ndim = len(shape)
+
+        lvl = jl.Element(fill_value, jl.Vector(data))
+        ptr = jl.Vector[jl.Int]([1, len(data) + 1])
+        tbl = tuple(jl.Vector(coords[i, :] + 1) for i in range(ndim))
+
+        jl_data = jl.SparseCOO[ndim](lvl, shape, ptr, tbl)
+
+        self._obj = jl.Tensor(jl_data)
+
+
+class _Compressed2D(Tensor):
+    def __init__(self, arg, shape, fill_value=0.0):
+        assert isinstance(arg, tuple) and len(arg) == 3
+        assert len(shape) == 2
+
+        data, indices, indptr = arg
+        data = jl.Vector(data)
+        indices = jl.Vector(indices + 1)
+        indptr = jl.Vector(indptr + 1)
+
+        lvl = jl.Element(fill_value, data)
+        jl_data = self.get_jl_data(shape, lvl, indptr, indices)
+        self._obj = jl.Tensor(jl_data)
+
+    @abstractmethod
+    def get_jl_data(
+        self,
+        shape: Tuple[int, int],
+        lvl: jc.AnyValue,
+        indptr: jc.VectorValue,
+        indices: jc.VectorValue,
+    ) -> jc.AnyValue:
+        ...
+
+
+class CSC(_Compressed2D):
+    def get_jl_data(self, shape, lvl, indptr, indices):
+        return jl.Dense(jl.SparseList(lvl, shape[0], indptr, indices), shape[1])
+
+
+class CSR(_Compressed2D):
+    def get_jl_data(self, shape, lvl, indptr, indices):
+        return jl.SparseList(jl.Dense(lvl, shape[0]), shape[1], indptr, indices)
+
 
 def fsprand(*args):
-    return Tensor(jl.fsprand(*args))
+    return Tensor(jl_data=jl.fsprand(*args))
+
+
+# LEVELS
+
+class AbstractLevel(_Display):
+    pass
+
+
+# core levels
+
+class Dense(AbstractLevel):
+    def __init__(self, lvl):
+        self._obj = jl.Dense(lvl._obj)
+
+
+class Element(AbstractLevel):
+    def __init__(self, val):
+        self._obj = jl.Element(val)
+
+
+class Pattern(AbstractLevel):
+    def __init__(self):
+        self._obj = jl.Pattern()
+
+
+# advanced levels
+
+class SparseList(AbstractLevel):
+    def __init__(self, lvl):
+        self._obj = jl.SparseList(lvl._obj)
+
+
+class SparseByteMap(AbstractLevel):
+    def __init__(self, lvl):
+        self._obj = jl.SparseByteMap(lvl._obj)
+
+
+class RepeatRLE(AbstractLevel):
+    def __init__(self, lvl):
+        self._obj = jl.RepeatRLE(lvl._obj)
+
+
+class SparseVBL(AbstractLevel):
+    def __init__(self, lvl):
+        self._obj = jl.SparseVBL(lvl._obj)
+
+
+class SparseCOO(AbstractLevel):
+    def __init__(self, ndim, lvl):
+        self._obj = jl.SparseCOO[ndim](lvl._obj)
+
+
+class SparseHash(AbstractLevel):
+    def __init__(self, ndim, lvl):
+        self._obj = jl.SparseHash[ndim](lvl._obj)

--- a/finch/tests/test_sparse.py
+++ b/finch/tests/test_sparse.py
@@ -1,16 +1,83 @@
+import numpy as np
+from numpy.testing import assert_equal
 import pytest
+import sparse
+
 import finch
+
 
 @pytest.fixture
 def x():
     return finch.fsprand(5, 5, 0.5)
 
+
 @pytest.fixture
 def y():
     return finch.fsprand(5, 5, 0.5)
 
-def test_add(x, y):
-    print(x.data)
-    print(y.data)
-    print((x + y).data)
-    assert True
+
+@pytest.fixture
+def rng():
+    return np.random.default_rng(42)
+
+
+def test_wrappers():
+    A = np.array([[0,0,4], [1,0,0], [2,0,5], [3,0,0]])
+    B = np.stack([A, A], axis=2)
+    scalar = finch.Tensor(finch.Element(2), np.array(2))
+
+    levels = finch.Dense(finch.SparseList(finch.SparseList(finch.Element(0.0))))
+    B_finch = finch.Tensor(levels, B)
+
+    assert_equal(B_finch.todense(), B)
+    assert_equal((B_finch * scalar + B_finch).todense(), B * 2 + B)
+
+
+    levels = finch.Dense(finch.Dense(finch.Element(1.0)))
+    B_finch = finch.Tensor(levels, A)
+
+    assert_equal(B_finch.todense(), A)
+    assert_equal((B_finch * scalar + B_finch).todense(), A * 2 + A)
+
+
+def test_coo(rng):
+    coords = np.asarray(
+        [[0, 1, 2, 3, 4], [0, 1, 2, 3, 4]],
+        dtype=np.intp,
+    )
+    data = rng.random(5)
+    scalar = finch.Tensor(finch.Element(2), np.array(2))
+
+    arr_pydata = sparse.COO(coords, data, shape=(5, 5))
+    arr = arr_pydata.todense()
+    arr_finch = finch.COO(coords, data, shape=(5, 5))
+
+    assert_equal(arr_finch.todense(), arr)
+    assert_equal((arr_finch * scalar + arr_finch).todense(), arr * 2 + arr)
+
+
+def test_csc(rng):
+    indices, indptr, data = np.arange(5), np.arange(6), rng.random(5)
+    scalar = finch.Tensor(finch.Element(2), np.array(2))
+
+    arr_pydata = sparse._compressed.CSC((data, indices, indptr), shape=(5, 5))
+    arr = arr_pydata.todense()
+    arr_finch = finch.CSC((data, indices, indptr), shape=(5, 5))
+
+    assert_equal(arr_finch.todense(), arr)
+    assert_equal((arr_finch * scalar + arr_finch).todense(), arr * 2 + arr)
+
+
+def test_csr(rng):
+    indices, indptr, data = np.arange(5), np.arange(6), rng.random(5)
+    scalar = finch.Tensor(finch.Element(2), np.array(2))
+
+    arr_pydata = sparse._compressed.CSR((data, indices, indptr), shape=(5, 5))
+    arr = arr_pydata.todense()
+
+    data_finch = np.zeros(25)
+    data_finch[::6] = data
+    arr_finch = finch.CSR((data_finch, indices, np.array([0, 5])), shape=(5, 5))
+
+    assert_equal(arr_finch.todense(), arr)
+    assert_equal((arr_finch * scalar + arr_finch).todense(), arr * 2 + arr)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,11 @@ requires-python = ">=3.8"
 dependencies = ["juliapkg>=0.1.10", "juliacall>=0.9.15"]
 
 [project.optional-dependencies]
-tests = ["pytest>=3.5", "sparse>=0.15.1"]
+tests = [
+    "pytest>=3.5",
+    "pytest-cov",
+    "sparse>=0.15.1",
+]
 
 [project.urls]
 Source = "https://github.com/willow-ahrens/finch-tensor"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --cov-report term-missing --cov-report html --cov-report=xml --cov-report=term --cov sparse --cov-config .coveragerc --junitxml=junit/test-results.xml
+addopts = --cov-report term-missing --cov-report html --cov-report=xml --cov-report=term --cov finch --cov-config .coveragerc --junitxml=junit/test-results.xml
 filterwarnings =
     ignore::PendingDeprecationWarning
 testpaths =


### PR DESCRIPTION
Hi @willow-ahrens @hameerabbasi,

Here's a PR with a draft implementation of Python wrappers for Tensor constructors, levels, COO, and CSC formats. Some comments:

- `test_coo` and `test_csc` show the construction of fibers using the same code as Hameer's notebook (which adheres to `pydata/sparse`). Tomorrow I will add `CSR` and `DOK/SparseHash` so the whole notebook can be executed (except for `GCXS`).
- Each wrapper has a `_obj` attribute which is the underlying Julia object.
- `Tensor` can be constructed by providing `levels` description (wrapper classes!) and NumPy/Finch array, or just Finch object directly (`jl_data`).
- Only simple element-wise operations are executed here.
- There's also an implementation of the `todense` function that is heavily used in `pydata/sparse`. Here it's done by constructing a new `lvl` description with `Dense` levels only and creating a new Tensor.
- In a separate PR (I think?) I will add CI stages for running those tests.

### Questions:
1. Is it possible to access `fill_value` in `Element`? I mean the first type parameter in `Element{0.0, Float64, Int64}(...)`
2. How can I get the shape tuple of `Tensor`? Right now I obtain shape by iterating through `level`s and aggregating `shape` into one tuple.