### PR TITLE
API: Add fully-dense no-copy and `scipy/numpy` input `Tensor` constructors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ pytest = "^7.4.4"
 pre-commit = "^3.6.0"
 pytest-cov = "^4.1.0"
 sparse = "^0.15.1"
+scipy = "^1.7"
 
 [build-system]
 requires = ["poetry-core"]

--- a/src/finch/__init__.py
+++ b/src/finch/__init__.py
@@ -1,5 +1,4 @@
-from .tensor import (
-    Tensor,
+from .levels import (
     Dense,
     Element,
     Pattern,
@@ -9,9 +8,14 @@ from .tensor import (
     SparseVBL,
     SparseCOO,
     SparseHash,
+    Storage,
+    DenseStorage,
 )
-from .tensor import fsprand, permute_dims
-from .tensor import COO, CSC, CSF, CSR
+from .tensor import (
+    Tensor,
+    fsprand,
+    permute_dims,
+)
 
 __all__ = [
     "Tensor",
@@ -24,10 +28,8 @@ __all__ = [
     "SparseVBL",
     "SparseCOO",
     "SparseHash",
+    "Storage",
+    "DenseStorage",
     "fsprand",
     "permute_dims",
-    "COO",
-    "CSC",
-    "CSF",
-    "CSR",
 ]

--- a/src/finch/julia.py
+++ b/src/finch/julia.py
@@ -1,6 +1,6 @@
 import juliapkg
 
-juliapkg.add("Finch", "9177782c-1635-4eb9-9bfb-d9dfa25e6bce", version="0.6.10")
+juliapkg.add("Finch", "9177782c-1635-4eb9-9bfb-d9dfa25e6bce", version="0.6.11")
 import juliacall  # noqa
 
 juliapkg.resolve()

--- a/src/finch/levels.py
+++ b/src/finch/levels.py
@@ -1,0 +1,93 @@
+import numpy as np
+
+from .julia import jl
+from .typing import OrderType
+
+
+class _Display:
+    def __repr__(self):
+        return jl.sprint(jl.show, self._obj)
+
+    def __str__(self):
+        return jl.sprint(jl.show, jl.MIME("text/plain"), self._obj)
+
+
+# LEVEL
+
+class AbstractLevel(_Display):
+    pass
+
+
+# core levels
+
+class Dense(AbstractLevel):
+    def __init__(self, lvl, shape=None):
+        args = [lvl._obj]
+        if shape is not None:
+            args.append(shape)
+        self._obj = jl.Dense(*args)
+
+
+class Element(AbstractLevel):
+    def __init__(self, fill_value, data=None):
+        args = [fill_value]
+        if data is not None:
+            args.append(data)
+        self._obj = jl.Element(*args)
+
+
+class Pattern(AbstractLevel):
+    def __init__(self):
+        self._obj = jl.Pattern()
+
+
+# advanced levels
+
+class SparseList(AbstractLevel):
+    def __init__(self, lvl):
+        self._obj = jl.SparseList(lvl._obj)
+
+
+class SparseByteMap(AbstractLevel):
+    def __init__(self, lvl):
+        self._obj = jl.SparseByteMap(lvl._obj)
+
+
+class RepeatRLE(AbstractLevel):
+    def __init__(self, lvl):
+        self._obj = jl.RepeatRLE(lvl._obj)
+
+
+class SparseVBL(AbstractLevel):
+    def __init__(self, lvl):
+        self._obj = jl.SparseVBL(lvl._obj)
+
+
+class SparseCOO(AbstractLevel):
+    def __init__(self, ndim, lvl):
+        self._obj = jl.SparseCOO[ndim](lvl._obj)
+
+
+class SparseHash(AbstractLevel):
+    def __init__(self, ndim, lvl):
+        self._obj = jl.SparseHash[ndim](lvl._obj)
+
+
+# STORAGE
+
+class Storage:
+    def __init__(self, levels_descr: AbstractLevel, order: OrderType = None):
+        self.levels_descr = levels_descr
+        self.order = order if order is not None else "C"
+
+    def __str__(self) -> str:
+        return f"Storage(lvl={str(self.levels_descr)}, order={self.order})"
+
+
+class DenseStorage(Storage):
+    def __init__(self, ndim: int, dtype: np.dtype, order: OrderType = None):
+        lvl = Element(np.int_(0).astype(dtype))
+        for _ in range(ndim):
+            lvl = Dense(lvl)
+
+        super().__init__(levels_descr=lvl, order=order)

--- a/src/finch/tensor.py
+++ b/src/finch/tensor.py
@@ -1,41 +1,39 @@
-from abc import abstractmethod
-from typing import Union
+from typing import Optional, Union
 
 import numpy as np
 import juliacall as jc
 
 from .julia import jl
-
-
-class _Display:
-    def __repr__(self):
-        return jl.sprint(jl.show, self._obj)
-
-    def __str__(self):
-        return jl.sprint(jl.show, jl.MIME("text/plain"), self._obj)
+from .levels import _Display, Dense, Element, Storage
+from .typing import OrderType, JuliaObj, spmatrix, TupleOf3Arrays
 
 
 class Tensor(_Display):
     """
     A wrapper class for Finch.Tensor and Finch.SwizzleArray.
 
-    Three constructors are supported: `lvl` with data, `lvl` with description + `arr`, or `jl_data`.
+    Constructors
+    ------------
+    Tensor(scipy.sparse.spmatrix)
+        Construct a Tensor out of a `scipy.sparse` object. Supported formats are: `COO`, `CSC`, and `CSR`.
+    Tensor(numpy.ndarray)
+        Construct a Tensor out of a NumPy array object. This is a no-copy operation.
+    Tensor(Storage)
+        Initialize a Tensor with a `storage` description. `storage` can already hold data.
+    Tensor(julia_object)
+        Tensor created from a compatible raw Julia object. Must be a `SwizzleArray`.
+        This is a no-copy operation.
 
     Parameters
     ----------
-    lvl : AbstractLevel, optional
-        Levels' description or levels with data. When level's description is passed then
-        `arr` parameter is required. A zero-copy fully dense tensor semantics is available
-        with levels with data constructor (see Examples section).
-    arr : ndarray, optional
-        NumPy array that should fill `lvl`. If provided `lvl` should only describe levels.
-    jl_data : Finch.SwizzleArray, optional
-        Raw Julia object.
-    order : str or tuple[int, ...], optional
-        Order of the tensor. The order numbers the dimensions from the fastest to slowest.
-        The leaf nodes have mode `0` and the root node has mode `n-1`. If the tensor was square
-        of size `N`, then `N .^ order == strides`. Available options are "C" (row-major),
-        "F" (column-major), or a custom order. Default: row-major.
+    obj : np.ndarray or scipy.sparse or Storage or Finch.SwizzleArray
+        Input to construct a Tensor. It's a no-copy operation of for NumPy and SciPy input. For Storage
+        it's levels' description with order. The order numbers the dimensions from the fastest to slowest.
+        The leaf nodes have mode `0` and the root node has mode `n-1`. If the tensor was square of size `N`,
+        then `N .^ order == strides`. Available options are "C" (row-major), "F" (column-major), or a custom
+        order. Default: row-major.
+    fill_value : np.number, optional
+        Only used when `arr : np.ndarray` is passed.
 
     Returns
     -------
@@ -46,62 +44,63 @@ class Tensor(_Display):
     --------
     >>> import numpy as np
     >>> import finch
-    >>> t1 = finch.Tensor(lvl=finch.Dense(finch.Element(0)), arr=np.arange(3))
+    >>> arr2d = np.arange(6).reshape((2, 3))
+    >>> t1 = finch.Tensor(arr2d)
     >>> t1.todense()
-    array([0, 1, 2])
-    >>> # no-copy dense constructor
-    >>> arr2d = np.ones((3, 4))
-    >>> levels = finch.Dense(finch.Dense(finch.Element(1, arr2d.ravel()), 4), 3)
-    >>> t2 = finch.Tensor(lvl=levels)
-    >>> np.shares_memory(t2.todense(), arr2d)
+    array([[0, 1, 2],
+           [3, 4, 5]])
+    >>> np.shares_memory(t1.todense(), arr2d)
     True
+    >>> storage = finch.Storage(finch.Dense(finch.SparseList(finch.Element(1))), order="C")
+    >>> t2 = t1.to_device(storage)
+    >>> t2.todense()
+    array([[0, 1, 2],
+           [3, 4, 5]])
     """
     row_major = "C"
     column_major = "F"
 
-    def __init__(self, lvl=None, arr=None, jl_data=None, order=None):
-        if arr is not None and not isinstance(arr, np.ndarray):
-            raise ValueError("For now only numpy input allowed.")
-
-        # constructor for levels description and NumPy array input
-        if lvl is not None and jl_data is None:
-            if arr is not None:
-                order = self.preprocess_order(order, arr.ndim)
-                inv_order = tuple(i - 1 for i in jl.invperm(order))
-                self._obj = jl.swizzle(jl.Tensor(lvl._obj, arr.transpose(inv_order)), *order)
-            else:
-                order = self.preprocess_order(order, self.get_lvl_ndim(lvl._obj))
-                self._obj = jl.swizzle(jl.Tensor(lvl._obj), *order)
-        # constructor for a raw julia object
-        elif jl_data is not None and lvl is None and arr is None:
-            if order is not None:
-                raise ValueError("When passing a julia object order can't be provided.")
-            if not jl.isa(jl_data, jl.Finch.SwizzleArray):
-                raise ValueError("`jl_data` must be a SwizzleArray.")
+    def __init__(
+        self,
+        obj: Union[np.ndarray, spmatrix, Storage, JuliaObj],
+        /,
+        *,
+        fill_value: np.number = 0.0,
+    ):
+        if _is_scipy_sparse_obj(obj):  # scipy constructor
+            jl_data = self._from_scipy_sparse(obj)
             self._obj = jl_data
+        elif isinstance(obj, np.ndarray):  # numpy constructor
+            jl_data = self._from_numpy(obj, fill_value=fill_value)
+            self._obj = jl_data
+        elif isinstance(obj, Storage):  # from-storage constructor
+            order = self.preprocess_order(obj.order, self.get_lvl_ndim(obj.levels_descr._obj))
+            self._obj = jl.swizzle(jl.Tensor(obj.levels_descr._obj), *order)
+        elif jl.isa(obj, jl.Finch.SwizzleArray):  # raw-Julia-object constructor
+            self._obj = obj
         else:
             raise ValueError(
-                "Either `lvl` and numpy `arr` should be provided or a raw julia object."
+                "Either `arr`, `storage` or a raw julia object should be provided."
             )
 
     def __pos__(self):
-        return Tensor(jl_data=jl.Base.broadcast(jl.seval("+"), self._obj))
+        return Tensor(jl.Base.broadcast(jl.seval("+"), self._obj))
 
     def __add__(self, other):
-        return Tensor(jl_data=jl.Base.broadcast(jl.seval("+"), self._obj, other._obj))
+        return Tensor(jl.Base.broadcast(jl.seval("+"), self._obj, other._obj))
 
     def __mul__(self, other):
-        return Tensor(jl_data=jl.Base.broadcast(jl.seval("*"), self._obj, other._obj))
+        return Tensor(jl.Base.broadcast(jl.seval("*"), self._obj, other._obj))
 
     def __sub__(self, other):
-        return Tensor(jl_data=jl.Base.broadcast(jl.seval("-"), self._obj, other._obj))
+        return Tensor(jl.Base.broadcast(jl.seval("-"), self._obj, other._obj))
 
     def __truediv__(self, other):
-        return Tensor(jl_data=jl.Base.broadcast(jl.seval("/"), self._obj, other._obj))
+        return Tensor(jl.Base.broadcast(jl.seval("/"), self._obj, other._obj))
 
     @property
     def dtype(self) -> jc.TypeValue:
-        return jl.eltype(self._obj)
+        return jl.eltype(self._obj.body)
 
     @property
     def ndim(self) -> int:
@@ -130,7 +129,7 @@ class Tensor(_Display):
 
     @classmethod
     def preprocess_order(
-        cls, order: Union[str, tuple[int, ...], None], ndim: int
+        cls, order: OrderType, ndim: int
     ) -> tuple[int, ...]:
         if order == cls.column_major:
             permutation = tuple(range(1, ndim + 1))
@@ -152,22 +151,22 @@ class Tensor(_Display):
         return permutation
 
     @classmethod
-    def get_lvl_ndim(cls, lvl) -> int:
+    def get_lvl_ndim(cls, lvl: JuliaObj) -> int:
         ndim = 0
-        for _ in range(np.MAXDIMS):
+        while True:
             ndim += 1
             lvl = lvl.lvl
             if jl.isa(lvl, jl.Finch.Element):
                 break
         return ndim
 
-    def get_order(self, zero_indexing=True) -> tuple[int, ...]:
+    def get_order(self, zero_indexing: bool = True) -> tuple[int, ...]:
         order = self._order
         if zero_indexing:
             order = tuple(i - 1 for i in order)
         return order
 
-    def get_inv_order(self, zero_indexing=True) -> tuple[int, ...]:
+    def get_inv_order(self, zero_indexing: bool = True) -> tuple[int, ...]:
         inv_order = jl.invperm(self._order)
         if zero_indexing:
             inv_order = tuple(i - 1 for i in inv_order)
@@ -197,63 +196,111 @@ class Tensor(_Display):
     def permute_dims(self, axes: tuple[int, ...]) -> "Tensor":
         axes = tuple(i + 1 for i in axes)
         new_obj = jl.swizzle(self._obj, *axes)
-        new_tensor = Tensor(jl_data=new_obj)
+        new_tensor = Tensor(new_obj)
         return new_tensor
 
+    def to_device(self, device: Storage) -> "Tensor":
+        return Tensor(self._from_other_tensor(self, storage=device))
 
-class COO(Tensor):
-    def __init__(self, coords, data, shape, fill_value=0.0):
-        assert coords.ndim == 2
+    @classmethod
+    def _from_other_tensor(cls, tensor: "Tensor", storage: Optional[Storage]) -> JuliaObj:
+        order = cls.preprocess_order(storage.order, tensor.ndim)
+        return jl.swizzle(
+            jl.Tensor(storage.levels_descr._obj, tensor._obj.body), *order
+        )
+
+    @classmethod
+    def _from_numpy(cls, arr: np.ndarray, fill_value: np.number) -> JuliaObj:
+        order_char = "F" if np.isfortran(arr) else "C"
+        order = cls.preprocess_order(order_char, arr.ndim)
+        inv_order = tuple(i - 1 for i in jl.invperm(order))
+
+        lvl = Element(arr.dtype.type(fill_value), arr.reshape(-1, order=order_char))
+        for i in inv_order:
+            lvl = Dense(lvl, arr.shape[i])
+        return jl.swizzle(jl.Tensor(lvl._obj), *order)
+
+    @classmethod
+    def _from_scipy_sparse(cls, x) -> JuliaObj:
+        if x.format == "coo":
+            return cls.construct_coo_jl_object(
+                coords=(x.col, x.row), data=x.data, shape=x.shape[::-1], order=Tensor.row_major
+            )
+        elif x.format == "csc":
+            return cls.construct_csc_jl_object(
+                arg=(x.data, x.indices, x.indptr),
+                shape=x.shape,
+            )
+        elif x.format == "csr":
+            return cls.construct_csr_jl_object(
+                arg=(x.data, x.indices, x.indptr),
+                shape=x.shape,
+            )
+        else:
+            raise ValueError(f"Unsupported SciPy format: {type(x)}")
+
+    @classmethod
+    def construct_coo_jl_object(cls, coords, data, shape, order, fill_value=0.0) -> JuliaObj:
+        assert len(coords) == 2
         ndim = len(shape)
+        order = cls.preprocess_order(order, ndim)
 
-        lvl = jl.Element(data.dtype.type(fill_value), jl.Vector(data))
+        lvl = jl.Element(data.dtype.type(fill_value), data)
         ptr = jl.Vector[jl.Int]([1, len(data) + 1])
-        tbl = tuple(jl.Vector(coords[i, :] + 1) for i in range(ndim))
+        tbl = tuple(jl.OffByOneVector(arr) for arr in coords)
 
-        jl_data = jl.SparseCOO[ndim](lvl, shape, ptr, tbl)
-        jl_data = jl.swizzle(jl.Tensor(jl_data), 1, 2)
+        jl_data = jl.swizzle(jl.Tensor(jl.SparseCOO[ndim](lvl, shape, ptr, tbl)), *order)
+        return jl_data
 
-        super().__init__(jl_data=jl_data)
+    @classmethod
+    def construct_coo(cls, coords, data, shape, order=row_major, fill_value=0.0) -> "Tensor":
+        return Tensor(cls.construct_coo_jl_object(coords, data, shape, order, fill_value))
 
-
-class _Compressed2D(Tensor):
-    def __init__(self, arg, shape, fill_value=0.0, order=Tensor.row_major):
+    @staticmethod
+    def _construct_compressed2d_jl_object(
+        arg: TupleOf3Arrays,
+        shape: tuple[int, ...],
+        order: tuple[int, ...],
+        fill_value: np.number = 0.0,
+    ) -> JuliaObj:
         assert isinstance(arg, tuple) and len(arg) == 3
         assert len(shape) == 2
 
         data, indices, indptr = arg
         dtype = data.dtype.type
-        data = jl.Vector(data)
-        indices = jl.Vector(indices + 1)
-        indptr = jl.Vector(indptr + 1)
+        indices = jl.OffByOneVector(indices)
+        indptr = jl.OffByOneVector(indptr)
 
         lvl = jl.Element(dtype(fill_value), data)
         jl_data = jl.swizzle(
-            jl.Tensor(
-                jl.Dense(jl.SparseList(lvl, shape[0], indptr, indices), shape[1])
-            ),
-            *self.get_permutation(order),
+            jl.Tensor(jl.Dense(jl.SparseList(lvl, shape[0], indptr, indices), shape[1])), *order
+        )
+        return jl_data
+
+    @classmethod
+    def construct_csc_jl_object(cls, arg: TupleOf3Arrays, shape: tuple[int, ...]) -> JuliaObj:
+        return cls._construct_compressed2d_jl_object(
+            arg=arg, shape=shape, order=(1, 2)
         )
 
-        super().__init__(jl_data=jl_data)
+    @classmethod
+    def construct_csc(cls, arg: TupleOf3Arrays, shape: tuple[int, ...]) -> "Tensor":
+        return Tensor(cls.construct_csc_jl_object(arg, shape))
 
-    @abstractmethod
-    def get_permutation(self, order: str) -> tuple[int, int]:
-        ...
+    @classmethod
+    def construct_csr_jl_object(cls, arg: TupleOf3Arrays, shape: tuple[int, ...]) -> JuliaObj:
+        return cls._construct_compressed2d_jl_object(
+            arg=arg, shape=shape[::-1], order=(2, 1)
+        )
 
+    @classmethod
+    def construct_csr(cls, arg: TupleOf3Arrays, shape: tuple[int, ...]) -> "Tensor":
+        return Tensor(cls.construct_csr_jl_object(arg, shape))
 
-class CSC(_Compressed2D):
-    def get_permutation(self, order: str) -> tuple[int, int]:
-        return (2, 1) if order == Tensor.row_major else (1, 2)
-
-
-class CSR(_Compressed2D):
-    def get_permutation(self, order: str) -> tuple[int, int]:
-        return (1, 2) if order == Tensor.row_major else (2, 1)
-
-
-class CSF(Tensor):
-    def __init__(self, arg, shape, fill_value=0.0):
+    @staticmethod
+    def construct_csf_jl_object(
+        arg: TupleOf3Arrays, shape: tuple[int, ...], fill_value: np.number = 0.0
+    ) -> JuliaObj:
         assert isinstance(arg, tuple) and len(arg) == 3
 
         data, indices_list, indptr_list = arg
@@ -262,86 +309,28 @@ class CSF(Tensor):
         assert len(indices_list) == len(shape) - 1
         assert len(indptr_list) == len(shape) - 1
 
-        data = jl.Vector(data)
-        indices_list = [jl.Vector(i + 1) for i in indices_list]
-        indptr_list = [jl.Vector(i + 1) for i in indptr_list]
+        indices_list = [jl.OffByOneVector(i) for i in indices_list]
+        indptr_list = [jl.OffByOneVector(i) for i in indptr_list]
 
         lvl = jl.Element(dtype(fill_value), data)
         for size, indices, indptr in zip(shape[:-1], indices_list, indptr_list):
             lvl = jl.SparseList(lvl, size, indptr, indices)
 
         jl_data = jl.swizzle(jl.Tensor(jl.Dense(lvl, shape[-1])), *range(1, len(shape) + 1))
+        return jl_data
 
-        super().__init__(jl_data=jl_data)
+    @classmethod
+    def construct_csf(cls, arg: TupleOf3Arrays, shape: tuple[int, ...]) -> "Tensor":
+        return Tensor(cls.construct_csf_jl_object(arg, shape))
 
 
 def fsprand(*args, order=None):
-    return Tensor(jl_data=jl.fsprand(*args), order=order)
+    return Tensor(jl.fsprand(*args))
 
 
 def permute_dims(x: Tensor, axes: tuple[int, ...]):
     return x.permute_dims(axes)
 
 
-# LEVELS
-
-
-class AbstractLevel(_Display):
-    pass
-
-
-# core levels
-
-
-class Dense(AbstractLevel):
-    def __init__(self, lvl, shape=None):
-        args = [lvl._obj]
-        if shape is not None:
-            args.append(shape)
-        self._obj = jl.Dense(*args)
-
-
-class Element(AbstractLevel):
-    def __init__(self, fill_value, data=None):
-        args = [fill_value]
-        if data is not None:
-            args.append(data)
-        self._obj = jl.Element(*args)
-
-
-class Pattern(AbstractLevel):
-    def __init__(self):
-        self._obj = jl.Pattern()
-
-
-# advanced levels
-
-
-class SparseList(AbstractLevel):
-    def __init__(self, lvl):
-        self._obj = jl.SparseList(lvl._obj)
-
-
-class SparseByteMap(AbstractLevel):
-    def __init__(self, lvl):
-        self._obj = jl.SparseByteMap(lvl._obj)
-
-
-class RepeatRLE(AbstractLevel):
-    def __init__(self, lvl):
-        self._obj = jl.RepeatRLE(lvl._obj)
-
-
-class SparseVBL(AbstractLevel):
-    def __init__(self, lvl):
-        self._obj = jl.SparseVBL(lvl._obj)
-
-
-class SparseCOO(AbstractLevel):
-    def __init__(self, ndim, lvl):
-        self._obj = jl.SparseCOO[ndim](lvl._obj)
-
-
-class SparseHash(AbstractLevel):
-    def __init__(self, ndim, lvl):
-        self._obj = jl.SparseHash[ndim](lvl._obj)
+def _is_scipy_sparse_obj(x):
+    return hasattr(x, "__module__") and x.__module__.startswith("scipy.sparse")

--- a/src/finch/typing.py
+++ b/src/finch/typing.py
@@ -1,0 +1,12 @@
+from typing import Any, Literal, Union
+
+import juliacall as jc
+import numpy as np
+
+OrderType = Union[Literal["C", "F"], tuple[int, ...], None]
+
+TupleOf3Arrays = tuple[np.ndarray, np.ndarray, np.ndarray]
+
+JuliaObj = jc.AnyValue
+
+spmatrix = Any

--- a/tests/test_scipy_constructors.py
+++ b/tests/test_scipy_constructors.py
@@ -1,0 +1,46 @@
+import numpy as np
+from numpy.testing import assert_equal
+import pytest
+import scipy.sparse as sp
+
+import finch
+
+
+@pytest.fixture
+def arr2d():
+    return np.array(
+        [
+            [0, 0, 3, 2, 0],
+            [1, 0, 0, 1, 0],
+            [0, 5, 0, 0, 0],
+        ]
+    )
+
+
+def test_scipy_coo(arr2d):
+    sp_arr = sp.coo_matrix(arr2d, dtype=np.int64)
+    finch_arr = finch.Tensor(sp_arr)
+    lvl = finch_arr._obj.body.lvl
+
+    assert np.shares_memory(sp_arr.row, lvl.tbl[1].data)
+    assert np.shares_memory(sp_arr.col, lvl.tbl[0].data)
+    assert np.shares_memory(sp_arr.data, lvl.lvl.val)
+
+    assert_equal(finch_arr.todense(), sp_arr.todense())
+    new_arr = finch.permute_dims(finch_arr, (1, 0))
+    assert_equal(new_arr.todense(), sp_arr.todense().transpose())
+
+
+@pytest.mark.parametrize("cls", [sp.csc_matrix, sp.csr_matrix])
+def test_scipy_compressed2d(arr2d, cls):
+    sp_arr = cls(arr2d, dtype=np.int64)
+    finch_arr = finch.Tensor(sp_arr)
+    lvl = finch_arr._obj.body.lvl.lvl
+
+    assert np.shares_memory(sp_arr.indices, lvl.idx.data)
+    assert np.shares_memory(sp_arr.indptr, lvl.ptr.data)
+    assert np.shares_memory(sp_arr.data, lvl.lvl.val)
+
+    assert_equal(finch_arr.todense(), sp_arr.todense())
+    new_arr = finch.permute_dims(finch_arr, (1, 0))
+    assert_equal(new_arr.todense(), sp_arr.todense().transpose())

--- a/tests/test_sparse.py
+++ b/tests/test_sparse.py
@@ -23,45 +23,34 @@ def rng():
 
 
 @pytest.mark.parametrize("dtype", [np.int64, np.float64, np.complex128])
-@pytest.mark.parametrize("order", ["C", "F"])
+@pytest.mark.parametrize("order", ["C", "F", None])
 def test_wrappers(dtype, order):
-    A = np.array([[0, 0, 4], [1, 0, 0], [2, 0, 5], [3, 0, 0]], dtype=dtype)
-    B = np.stack([A, A], axis=2, dtype=dtype)
-    scalar = finch.Tensor(finch.Element(2), np.array(2), order=order)
+    A = np.array([[0, 0, 4], [1, 0, 0], [2, 0, 5], [3, 0, 0]], dtype=dtype, order=order)
+    B = np.array(np.stack([A, A], axis=2, dtype=dtype), order=order)
 
-    levels = finch.Dense(finch.SparseList(finch.SparseList(finch.Element(dtype(0.0)))))
-    B_finch = finch.Tensor(levels, B, order=order)
+    B_finch = finch.Tensor(B)
+
+    storage = finch.Storage(
+        finch.Dense(finch.SparseList(finch.SparseList(finch.Element(dtype(0.0))))), order=order
+    )
+    B_finch = B_finch.to_device(storage)
 
     assert_equal(B_finch.todense(), B)
-    #assert_equal((B_finch * scalar + B_finch).todense(), B * 2 + B)
 
-    levels = finch.Dense(finch.Dense(finch.Element(dtype(1.0))))
-    A_finch = finch.Tensor(levels, A, order=order)
+    storage = finch.Storage(
+        finch.Dense(finch.Dense(finch.Element(dtype(1.0)))), order=order
+    )
+    A_finch = finch.Tensor(A).to_device(storage)
 
     assert_equal(A_finch.todense(), A)
-    #assert_equal((A_finch * scalar + A_finch).todense(), A * 2 + A)
-
     assert A_finch.todense().dtype == A.dtype and B_finch.todense().dtype == B.dtype
 
 
 @pytest.mark.parametrize("dtype", [np.int64, np.float64, np.complex128])
-@pytest.mark.parametrize("order", ["C", "F"])
+@pytest.mark.parametrize("order", ["C", "F", None])
 def test_no_copy_fully_dense(dtype, order, arr3d):
     arr = np.array(arr3d, dtype=dtype, order=order)
-    arr_in = arr.transpose(None) if order == "F" else arr
-    arr_shape = arr_in.shape
-
-    levels = finch.Dense(
-        finch.Dense(
-            finch.Dense(
-                finch.Element(dtype(0.0), arr_in.reshape(-1)),
-                arr_shape[2]
-            ),
-            arr_shape[1]
-        ),
-        arr_shape[0]
-    )
-    arr_finch = finch.Tensor(lvl=levels, order=order)
+    arr_finch = finch.Tensor(arr)
     arr_todense = arr_finch.todense()
 
     assert_equal(arr_todense, arr)
@@ -69,46 +58,40 @@ def test_no_copy_fully_dense(dtype, order, arr3d):
 
 
 def test_coo(rng):
-    coords = np.asarray(
-        [[0, 1, 2, 3, 4], [0, 1, 2, 3, 4]],
-        dtype=np.intp,
+    coords = (
+        np.asarray([0, 1, 2, 3, 4], dtype=np.intp),
+        np.asarray([0, 1, 2, 3, 4], dtype=np.intp),
     )
     data = rng.random(5)
-    scalar = finch.Tensor(finch.Element(2), np.array(2))
 
-    arr_pydata = sparse.COO(coords, data, shape=(5, 5))
+    arr_pydata = sparse.COO(np.vstack(coords), data, shape=(5, 5))
     arr = arr_pydata.todense()
-    arr_finch = finch.COO(coords, data, shape=(5, 5))
+    arr_finch = finch.Tensor.construct_coo(coords, data, shape=(5, 5))
 
     assert_equal(arr_finch.todense(), arr)
-    #assert_equal((arr_finch * scalar + arr_finch).todense(), arr * 2 + arr)
-
     assert arr_finch.todense().dtype == data.dtype
 
 
 @pytest.mark.parametrize(
     "classes",
-    [(sparse._compressed.CSC, finch.CSC), (sparse._compressed.CSR, finch.CSR)],
+    [(sparse._compressed.CSC, finch.Tensor.construct_csc),
+     (sparse._compressed.CSR, finch.Tensor.construct_csr)],
 )
 def test_compressed2d(rng, classes):
     sparse_class, finch_class = classes
     indices, indptr, data = np.arange(5), np.arange(6), rng.random(5)
-    scalar = finch.Tensor(finch.Element(2), np.array(2))
 
     arr_pydata = sparse_class((data, indices, indptr), shape=(5, 5))
     arr = arr_pydata.todense()
     arr_finch = finch_class((data, indices, indptr), shape=(5, 5))
 
     assert_equal(arr_finch.todense(), arr)
-    #assert_equal((arr_finch * scalar + arr_finch).todense(), arr * 2 + arr)
-
     assert arr_finch.todense().dtype == data.dtype
 
 
 def test_csf(arr3d):
     arr = arr3d
     dtype = np.int64
-    scalar = finch.Tensor(finch.Element(2), np.array(2))
 
     data = np.array([4, 1, 2, 1, 1, 2, 5, -1, 3, 3], dtype=dtype)
     indices_list = [
@@ -119,11 +102,9 @@ def test_csf(arr3d):
         np.array([0, 1, 4, 5, 7, 8, 10], dtype=dtype), np.array([0, 2, 4, 5, 6], dtype=dtype)
     ]
 
-    arr_finch = finch.CSF((data, indices_list, indptr_list), shape=(3, 2, 4))
+    arr_finch = finch.Tensor.construct_csf((data, indices_list, indptr_list), shape=(3, 2, 4))
 
     assert_equal(arr_finch.todense(), arr)
-    #assert_equal((arr_finch * scalar + arr_finch).todense(), arr * 2 + arr)
-
     assert arr_finch.todense().dtype == data.dtype
 
 
@@ -132,10 +113,12 @@ def test_csf(arr3d):
 )
 @pytest.mark.parametrize("order", ["C", "F"])
 def test_permute_dims(arr3d, permutation, order):
-    arr = arr3d
+    arr = np.array(arr3d, order=order)
+    storage = finch.Storage(
+        finch.Dense(finch.SparseList(finch.SparseList(finch.Element(0)))), order=order
+    )
 
-    levels = finch.Dense(finch.SparseList(finch.SparseList(finch.Element(0))))
-    arr_finch = finch.Tensor(levels, arr, order=order)
+    arr_finch = finch.Tensor(arr).to_device(storage)
 
     actual = finch.permute_dims(arr_finch, permutation)
     expected = np.transpose(arr, permutation)


### PR DESCRIPTION
Hi @willow-ahrens @hameerabbasi,

This PR contains:
1. `finch.Tensor(scipy.sparse.spmatrix)` and `finch.Tensor(numpy.ndarray)` constructors.
2. Support for no-copy constructor for fully dense Tensors.
3. `levels.py` and `utils.py` files to clean up the code a bit. 
4. `Storage` class for device support. 
