### PR TITLE
API: Add `from_scipy` constructors to `COO`, `CSC`, and `CSR` formats

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ python = "^3.9"
 juliapkg = "^0.1.10"
 juliacall = "^0.9.15"
 numpy = "^1.19"
+scipy = "^1.7"
 
 [tool.poetry.group.test.dependencies]
 pytest = "^7.4.4"

--- a/tests/test_scipy_constructors.py
+++ b/tests/test_scipy_constructors.py
@@ -1,0 +1,29 @@
+import numpy as np
+from numpy.testing import assert_equal
+import pytest
+import scipy.sparse as sp
+
+import finch
+
+
+@pytest.fixture
+def arr2d():
+    return np.array(
+        [
+            [0, 0, 3, 2, 0],
+            [1, 0, 0, 1, 0],
+            [0, 5, 0, 0, 0],
+        ]
+    )
+
+
+@pytest.mark.parametrize(
+    "classes",
+    [(sp.coo_matrix, finch.COO), (sp.csc_matrix, finch.CSC), (sp.csr_matrix, finch.CSR)],
+)
+def test_scipy_constructor(arr2d, classes):
+    scipy_class, finch_class = classes
+    sp_arr = scipy_class(arr2d, dtype=np.int64)
+    finch_arr = finch_class.from_scipy_sparse(sp_arr)
+
+    assert_equal(finch_arr.todense(), sp_arr.todense())

--- a/tests/test_sparse.py
+++ b/tests/test_sparse.py
@@ -58,14 +58,14 @@ def test_no_copy_fully_dense(dtype, order, arr3d):
 
 
 def test_coo(rng):
-    coords = np.asarray(
-        [[0, 1, 2, 3, 4], [0, 1, 2, 3, 4]],
-        dtype=np.intp,
+    coords = (
+        np.asarray([0, 1, 2, 3, 4], dtype=np.intp),
+        np.asarray([0, 1, 2, 3, 4], dtype=np.intp),
     )
     data = rng.random(5)
     scalar = finch.Tensor(finch.Element(2), np.array(2))
 
-    arr_pydata = sparse.COO(coords, data, shape=(5, 5))
+    arr_pydata = sparse.COO(np.vstack(coords), data, shape=(5, 5))
     arr = arr_pydata.todense()
     arr_finch = finch.COO(coords, data, shape=(5, 5))
 


### PR DESCRIPTION
Hi @willow-ahrens @hameerabbasi,

This PR adds `from_scipy` constructors to `COO`, `CSR`, and `CSC` formats.

Once we have: https://github.com/willow-ahrens/Finch.jl/pull/405 merged and https://github.com/willow-ahrens/Finch.jl/issues/406 solved I will update them to a no-copy version.