### PR TITLE
API: Implement indexing and slicing for `Tensor`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,34 @@
+import numpy as np
+import pytest
+
+
+@pytest.fixture
+def rng():
+    return np.random.default_rng(42)
+
+
+@pytest.fixture
+def arr1d():
+    return np.arange(100)
+
+
+@pytest.fixture
+def arr2d():
+    return np.array(
+        [
+            [0, 0, 3, 2, 0],
+            [1, 0, 0, 1, 0],
+            [0, 5, 0, 0, 0],
+        ]
+    )
+
+
+@pytest.fixture
+def arr3d():
+    return np.array(
+        [
+            [[0, 1, 0, 0], [1, 0, 0, 3]],
+            [[4, 0, -1, 0], [2, 2, 0, 0]],
+            [[0, 0, 0, 0], [1, 5, 0, 3]],
+        ]
+    )

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -1,0 +1,80 @@
+import numpy as np
+from numpy.testing import assert_equal
+import pytest
+
+import finch
+
+
+@pytest.mark.parametrize(
+    "index", [..., 40, (32,), slice(None), slice(30, 60, 3), -10, slice(None, -10, -2)]
+)
+@pytest.mark.parametrize("order", ["C", "F"])
+def test_indexing_1d(arr1d, index, order):
+    arr = np.array(arr1d, order=order)
+    arr_finch = finch.Tensor(arr)
+
+    actual = arr_finch[index]
+    expected = arr[index]
+
+    if isinstance(actual, finch.Tensor):
+        actual = actual.todense()
+
+    assert_equal(actual, expected)
+
+
+@pytest.mark.parametrize(
+    "index", [..., 0, (2,), (2, 3), slice(None), (..., slice(0, 4, 2)), (-1, slice(-1, None, -1))]
+)
+@pytest.mark.parametrize("order", ["C", "F"])
+def test_indexing_2d(arr2d, index, order):
+    arr = np.array(arr2d, order=order)
+    arr_finch = finch.Tensor(arr)
+
+    actual = arr_finch[index]
+    expected = arr[index]
+
+    if isinstance(actual, finch.Tensor):
+        actual = actual.todense()
+
+    assert_equal(actual, expected)
+
+
+@pytest.mark.parametrize(
+    "index",
+    [
+        (0, 1, 2), (1, 0, 0), (0, 1), 1, 2,
+        (2, slice(None), 3), (slice(None), 0), slice(None),
+        (0, slice(None), slice(1, 4, 2)),
+        (0, 1, ...), (..., 1), (0, ..., 1), ..., (..., slice(1, 4, 2)),
+        (slice(None, None, -1), slice(None, None, -1), slice(None, None, -1)),
+        (slice(None, -1, 1), slice(-1, None, -1), slice(4, 1, -1)),
+        (-1, 0, 0), (0, -1, -2), ([1, 2], 0, slice(3, None, -1)),
+        (0, slice(1, 0, -1), 0),
+    ]
+)
+@pytest.mark.parametrize(
+    "levels_descr", [
+        finch.Dense(finch.Dense(finch.Dense(finch.Element(0)))),
+        finch.Dense(finch.SparseList(finch.SparseList(finch.Element(0)))),
+    ]
+)
+@pytest.mark.parametrize("order", ["C", "F"])
+def test_indexing_3d(arr3d, index, levels_descr, order):
+    arr = np.array(arr3d, order=order)
+    storage = finch.Storage(levels_descr, order=order)
+    arr_finch = finch.Tensor(arr).to_device(storage)
+
+    actual = arr_finch[index]
+    expected = arr[index]
+
+    if isinstance(actual, finch.Tensor):
+        actual = actual.todense()
+
+    assert_equal(actual, expected)
+
+
+def test_index_none(arr3d):
+    arr_finch = finch.Tensor(arr3d)
+
+    with pytest.raises(IndexError, match="'None' in the index key isn't supported"):
+        arr_finch[..., None]

--- a/tests/test_scipy_constructors.py
+++ b/tests/test_scipy_constructors.py
@@ -6,17 +6,6 @@ import scipy.sparse as sp
 import finch
 
 
-@pytest.fixture
-def arr2d():
-    return np.array(
-        [
-            [0, 0, 3, 2, 0],
-            [1, 0, 0, 1, 0],
-            [0, 5, 0, 0, 0],
-        ]
-    )
-
-
 def test_scipy_coo(arr2d):
     sp_arr = sp.coo_matrix(arr2d, dtype=np.int64)
     finch_arr = finch.Tensor(sp_arr)

--- a/tests/test_sparse.py
+++ b/tests/test_sparse.py
@@ -6,22 +6,6 @@ import sparse
 import finch
 
 
-@pytest.fixture
-def arr3d():
-    return np.array(
-        [
-            [[0, 1, 0, 0], [1, 0, 0, 3]],
-            [[4, 0, -1, 0], [2, 2, 0, 0]],
-            [[0, 0, 0, 0], [1, 5, 0, 3]],
-        ]
-    )
-
-
-@pytest.fixture
-def rng():
-    return np.random.default_rng(42)
-
-
 @pytest.mark.parametrize("dtype", [np.int64, np.float64, np.complex128])
 @pytest.mark.parametrize("order", ["C", "F", None])
 def test_wrappers(dtype, order):


### PR DESCRIPTION
Hi @willow-ahrens @hameerabbasi,

This PR implements indexing and slicing functionality to `Tensor` class. Following [Array API standard](https://data-apis.org/array-api/latest/API_specification/generated/array_api.array.__getitem__.html), indexing can be performed with: ints `a[1, 3]`, slices `a[:, 1:10:2]`, ellipsis `a[8, ...]`, and arrays/lists `a[:, [1,1,2]]`. Missing dims are expanded to `:`, so for 3-D array, `array[4]` is equal to `array[4, :, :]`.

AFAIK Julia doesn't support Ellipsis, so I implemented expanding it to slices here. Also, Finch Tensor accepts ranges instead of slices, so I convert `slice(...)` to `jl.range(...)`.

For 1-D tests to pass https://github.com/willow-ahrens/Finch.jl/issues/427 needs to be solved first.