### PR TITLE
API: `finch.astype` function

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -597,4 +597,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "71a7cde7f28fc96c03e15c879c3e0b31e825b3496aed9f18a902347c02b4c6a5"
+content-hash = "434f750dcd23939c57d2dc04efe69e411fb538b91119b6c79fc114b4ebc5d61d"

--- a/src/finch/__init__.py
+++ b/src/finch/__init__.py
@@ -13,8 +13,27 @@ from .levels import (
 )
 from .tensor import (
     Tensor,
+    astype,
     fsprand,
     permute_dims,
+)
+from .dtypes import (
+    int_,
+    int8,
+    int16,
+    int32,
+    int64,
+    uint,
+    uint8,
+    uint16,
+    uint32,
+    uint64,
+    float16,
+    float32,
+    float64,
+    complex64,
+    complex128,
+    bool,
 )
 
 __all__ = [
@@ -30,6 +49,23 @@ __all__ = [
     "SparseHash",
     "Storage",
     "DenseStorage",
+    "astype",
     "fsprand",
     "permute_dims",
+    "int_",
+    "int8",
+    "int16",
+    "int32",
+    "int64",
+    "uint",
+    "uint8",
+    "uint16",
+    "uint32",
+    "uint64",
+    "float16",
+    "float32",
+    "float64",
+    "complex64",
+    "complex128",
+    "bool",
 ]

--- a/src/finch/dtypes.py
+++ b/src/finch/dtypes.py
@@ -1,0 +1,19 @@
+from .julia import jl
+
+
+int_: jl.DataType = jl.Int
+int8: jl.DataType = jl.Int8
+int16: jl.DataType = jl.Int16
+int32: jl.DataType = jl.Int32
+int64: jl.DataType = jl.Int64
+uint: jl.DataType = jl.UInt
+uint8: jl.DataType = jl.UInt8
+uint16: jl.DataType = jl.UInt16
+uint32: jl.DataType = jl.UInt32
+uint64: jl.DataType = jl.UInt64
+float16: jl.DataType = jl.Float16
+float32: jl.DataType = jl.Float32
+float64: jl.DataType = jl.Float64
+complex64: jl.DataType = jl.ComplexF32
+complex128: jl.DataType = jl.ComplexF64
+bool: jl.DataType = jl.Bool

--- a/src/finch/julia.py
+++ b/src/finch/julia.py
@@ -1,6 +1,6 @@
 import juliapkg
 
-juliapkg.add("Finch", "9177782c-1635-4eb9-9bfb-d9dfa25e6bce", version="0.6.11")
+juliapkg.add("Finch", "9177782c-1635-4eb9-9bfb-d9dfa25e6bce", version="0.6.14")
 import juliacall  # noqa
 
 juliapkg.resolve()


### PR DESCRIPTION
Hi @willow-ahrens @hameerabbasi!

This PR introduces Array API [`astype` function](https://data-apis.org/array-api/latest/API_specification/generated/array_api.astype.html) (without `device` keyword arg for now).

The test suite will pass once https://github.com/willow-ahrens/Finch.jl/pull/438 is merged and a new release is published. 