### PR TITLE
API: Lazy API

### DIFF
--- a/src/finch/__init__.py
+++ b/src/finch/__init__.py
@@ -16,6 +16,20 @@ from .tensor import (
     astype,
     fsprand,
     permute_dims,
+    multiply,
+    sum,
+    prod,
+    add,
+    subtract,
+    multiply,
+    divide,
+    positive,
+    negative,
+)
+from .compiled import (
+    lazy,
+    compiled,
+    compute,
 )
 from .dtypes import (
     int_,
@@ -68,4 +82,16 @@ __all__ = [
     "complex64",
     "complex128",
     "bool",
+    "multiply",
+    "lazy",
+    "compiled",
+    "compute",
+    "sum",
+    "prod",
+    "add",
+    "subtract",
+    "multiply",
+    "divide",
+    "positive",
+    "negative",
 ]

--- a/src/finch/compiled.py
+++ b/src/finch/compiled.py
@@ -1,0 +1,34 @@
+from functools import wraps
+
+from .julia import jl
+from .tensor import Tensor
+
+
+def compiled(func):
+    @wraps(func)
+    def wrapper_func(*args, **kwargs):
+        new_args = []
+        for arg in args:
+            if isinstance(arg, Tensor) and not jl.isa(arg._obj, jl.Finch.LazyTensor):
+                new_args.append(Tensor(jl.Finch.LazyTensor(arg._obj)))
+            else:
+                new_args.append(arg)
+
+        result = func(*new_args, **kwargs)
+        result_tensor = Tensor(jl.Finch.compute(result._obj))
+
+        return result_tensor
+
+    return wrapper_func
+
+
+def lazy(tensor: Tensor):
+    if tensor.is_computed():
+        return Tensor(jl.Finch.LazyTensor(tensor._obj))
+    return tensor
+
+
+def compute(tensor: Tensor):
+    if not tensor.is_computed():
+        return Tensor(jl.Finch.compute(tensor._obj))
+    return tensor

--- a/src/finch/julia.py
+++ b/src/finch/julia.py
@@ -1,6 +1,6 @@
 import juliapkg
 
-juliapkg.add("Finch", "9177782c-1635-4eb9-9bfb-d9dfa25e6bce", version="0.6.16")
+juliapkg.add("Finch", "9177782c-1635-4eb9-9bfb-d9dfa25e6bce", version="0.6.19")
 import juliacall  # noqa
 
 juliapkg.resolve()

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -1,0 +1,88 @@
+import numpy as np
+from numpy.testing import assert_equal
+import pytest
+
+import finch
+
+
+arr2d = np.array([[1, 2, 0, 0], [0, 1, 0, 1]])
+
+arr1d = np.array([1, 1, 2, 3])
+
+
+def test_eager(arr3d):
+    A_finch = finch.Tensor(arr3d)
+    B_finch = finch.Tensor(arr2d)
+
+    result = finch.multiply(A_finch, B_finch)
+
+    assert_equal(result.todense(), np.multiply(arr3d, arr2d))
+
+
+def test_lazy_mode(arr3d):
+    A_finch = finch.Tensor(arr3d)
+    B_finch = finch.Tensor(arr2d)
+    C_finch = finch.Tensor(arr1d)
+
+    @finch.compiled
+    def my_custom_fun(arr1, arr2, arr3):
+        temp = finch.multiply(arr1, arr2)
+        temp = finch.divide(temp, arr3)
+        reduced = finch.sum(temp, axis=(0, 1))
+        return finch.add(temp, reduced)
+
+    result = my_custom_fun(A_finch, B_finch, C_finch)
+
+    temp = np.divide(np.multiply(arr3d, arr2d), arr1d)
+    expected = np.add(temp, np.sum(temp, axis=(0, 1)))
+    assert_equal(result.todense(), expected)
+
+    A_lazy = finch.lazy(A_finch)
+    B_lazy = finch.lazy(B_finch)
+    mul_lazy = finch.multiply(A_lazy, B_lazy)
+    result = finch.compute(mul_lazy)
+
+    assert_equal(result.todense(), np.multiply(arr3d, arr2d))
+
+
+@pytest.mark.parametrize(
+    "meth_name", ["__pos__", "__neg__", "__abs__"],
+)
+def test_elemwise_ops_1_arg(arr3d, meth_name):
+    A_finch = finch.Tensor(arr3d)
+
+    actual = getattr(A_finch, meth_name)()
+    expected = getattr(arr3d, meth_name)()
+
+    assert_equal(actual.todense(), expected)
+
+
+@pytest.mark.parametrize(
+    "meth_name",
+    ["__add__", "__mul__", "__sub__", "__truediv__", # "__floordiv__", "__mod__",
+     "__pow__", "__and__", "__or__", "__xor__", "__lshift__", "__rshift__"],
+)
+def test_elemwise_ops_2_args(arr3d, meth_name):
+    arr2d = np.array([[2, 3, 2, 3], [3, 2, 3, 2]])
+    A_finch = finch.Tensor(arr3d)
+    B_finch = finch.Tensor(arr2d)
+
+    actual = getattr(A_finch, meth_name)(B_finch)
+    expected = getattr(arr3d, meth_name)(arr2d)
+
+    assert_equal(actual.todense(), expected)
+
+
+@pytest.mark.parametrize("func_name", ["sum", "prod"])
+@pytest.mark.parametrize("axis", [None, -1, 1, (0, 1), (0, 1, 2)])
+@pytest.mark.parametrize("dtype", [None])
+def test_reductions(arr3d, func_name, axis, dtype):
+    A_finch = finch.Tensor(arr3d)
+
+    actual = getattr(finch, func_name)(A_finch, axis=axis, dtype=dtype)
+    expected = getattr(np, func_name)(arr3d, axis=axis, dtype=dtype)
+
+    if isinstance(actual, finch.Tensor):
+        actual = actual.todense()
+
+    assert_equal(actual, expected)


### PR DESCRIPTION
Hi @willow-ahrens @hameerabbasi,

This is a draft PR to start the discussion around targeting lazy API in Python. 
`Finch.jl` PR: https://github.com/willow-ahrens/Finch.jl/pull/389

Here's the first idea:
1. ~~`Tensor` class gains a new (private) attribute, `lazy_mode` indicating whether this tensor is taking part in lazy or eager computations.~~
2. ~~Each implemented Array API function (here please look at `def multiply(...)`) wraps input in `LogicTensor` from julia in case it's a raw SwizzleArray.~~
3. Here, as `multiply` is an elem-wise operation we need to ensure Python-style broadcasting (appending missing dimensions to the front). We first invert dims of both arrays, multiply element-wise, and invert back. 
4. If it's an eager mode, we call `Finch.compute` immediately, otherwise the "computation graph" result is returned.
5. ~~The `@compile` (or `@fuse` as we called it originally) sets `lazy_mode` flag to true for all input tensors, calls decorated function and then calls `Finch.compute`. Thanks to this flag all operations within decorated function will be "lazy".~~

I guess `swizzle(in::LogicTensor, dims)` also needs to be implemented.

We should be able to execute the Array API script (https://gist.github.com/mtsokol/f7772df523c05a28116bde75d1d9d3b6) in an eager and `@compile`/lazy mode.

Please share your thoughts! 