### PR TITLE
API: Add support for scalars

### DIFF
--- a/src/finch/tensor.py
+++ b/src/finch/tensor.py
@@ -62,16 +62,22 @@ class Tensor(_Display):
 
     def __init__(
         self,
-        obj: Union[np.ndarray, spmatrix, Storage, JuliaObj],
+        obj: Union[np.ndarray, np.number, spmatrix, Storage, JuliaObj],
         /,
         *,
-        fill_value: np.number = 0.0,
+        fill_value: Optional[np.number] = None,
     ):
         if _is_scipy_sparse_obj(obj):  # scipy constructor
             jl_data = self._from_scipy_sparse(obj)
             self._obj = jl_data
         elif isinstance(obj, np.ndarray):  # numpy constructor
+            fill_value = 0.0 if fill_value is None else fill_value
             jl_data = self._from_numpy(obj, fill_value=fill_value)
+            self._obj = jl_data
+        elif np.isscalar(obj):
+            if fill_value is not None:
+                raise UserWarning("`fill_value` argument is ignored for scalar input")
+            jl_data = self._from_numpy(obj, fill_value=obj)
             self._obj = jl_data
         elif isinstance(obj, Storage):  # from-storage constructor
             order = self.preprocess_order(obj.order, self.get_lvl_ndim(obj.levels_descr._obj))

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -86,3 +86,16 @@ def test_reductions(arr3d, func_name, axis, dtype):
         actual = actual.todense()
 
     assert_equal(actual, expected)
+
+
+def test_scalars(arr3d):
+    A_finch = finch.Tensor(arr3d)
+    result = A_finch + finch.Tensor(np.array(1))
+
+    assert result._is_dense
+
+    storage = finch.Storage(finch.Dense(finch.SparseList(finch.SparseList(finch.Element(0)))))
+    B_finch = A_finch.to_device(storage)
+    result = B_finch + finch.Tensor(np.array(1))  # SwizzleArray(Tensor(Element{1, Int64, Int64}([1])), ())
+
+    assert not result._is_dense


### PR DESCRIPTION
Issue: #25 

Hi @willow-ahrens @hameerabbasi,

This is a WIP PR that is meant to introduce support and tests for scalars. It will change as the discussion about scalars continues.

Out of curiosity I tried to represent scalars as: `SwizzleArray(Tensor(Element{1, Int64, Int64}([1])), ())`, but as expected, for some operations it causes densification of Tensors. 