### PR TITLE
API: Add `Tensor.to_scipy_sparse`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "finch-tensor"
-version = "0.1.9"
+version = "0.1.10"
 description = ""
 authors = ["Willow Ahrens <willow.marie.ahrens@gmail.com>"]
 readme = "README.md"

--- a/src/finch/__init__.py
+++ b/src/finch/__init__.py
@@ -13,6 +13,7 @@ from .levels import (
 )
 from .tensor import (
     Tensor,
+    SparseArray,
     asarray,
     astype,
     random,
@@ -72,6 +73,7 @@ from .dtypes import (
 
 __all__ = [
     "Tensor",
+    "SparseArray",
     "Dense",
     "Element",
     "Pattern",

--- a/src/finch/julia.py
+++ b/src/finch/julia.py
@@ -1,6 +1,6 @@
 import juliapkg
 
-_FINCH_VERSION = "0.6.20"
+_FINCH_VERSION = "0.6.21"
 _FINCH_HASH = "9177782c-1635-4eb9-9bfb-d9dfa25e6bce"
 
 deps = juliapkg.deps.load_cur_deps()

--- a/src/finch/levels.py
+++ b/src/finch/levels.py
@@ -73,6 +73,19 @@ class SparseHash(AbstractLevel):
         self._obj = jl.SparseHash[ndim](lvl._obj)
 
 
+sparse_formats_names = (
+    "SparseList",
+    "Sparse",
+    "SparseHash",
+    "SparseCOO",
+    "SparseRLE",
+    "SparseVBL",
+    "SparseBand",
+    "SparsePoint",
+    "SparseInterval",
+)
+
+
 # STORAGE
 
 class Storage:

--- a/src/finch/tensor.py
+++ b/src/finch/tensor.py
@@ -9,7 +9,13 @@ from .levels import _Display, Dense, Element, Storage, DenseStorage, SparseCOO, 
 from .typing import OrderType, JuliaObj, spmatrix, TupleOf3Arrays, DType
 
 
-class Tensor(_Display):
+class SparseArray:
+    """
+    PyData/Sparse marker class
+    """
+
+
+class Tensor(_Display, SparseArray):
     """
     A wrapper class for Finch.Tensor and Finch.SwizzleArray.
 
@@ -305,6 +311,12 @@ class Tensor(_Display):
         return jl.swizzle(jl.Tensor(lvl._obj), *order)
 
     @classmethod
+    def from_scipy_sparse(cls, x) -> "Tensor":
+        if not _is_scipy_sparse_obj(x):
+            raise ValueError("{x} is not a SciPy sparse object.")
+        return Tensor(x)
+
+    @classmethod
     def _from_scipy_sparse(cls, x) -> JuliaObj:
         if x.format == "coo":
             return cls.construct_coo_jl_object(
@@ -407,6 +419,35 @@ class Tensor(_Display):
     def construct_csf(cls, arg: TupleOf3Arrays, shape: tuple[int, ...]) -> "Tensor":
         return Tensor(cls.construct_csf_jl_object(arg, shape))
 
+    def to_scipy_sparse(self):
+        import scipy.sparse as sp
+
+        if self.ndim != 2:
+            raise ValueError("Can only convert a 2-dimensional array to a Scipy sparse matrix.")
+        if self.fill_value != 0:
+            raise ValueError("Can only convert arrays with 0 fill value to a Scipy sparse matrix.")
+        order = self.get_order()
+        body = self._obj.body
+
+        if str(jl.typeof(body.lvl).name.name) == "SparseCOOLevel":
+            data = np.asarray(body.lvl.lvl.val)
+            coords = body.lvl.tbl
+            row, col = coords[::-1] if order == (1, 0) else coords
+            row, col = np.asarray(row) - 1, np.asarray(col) - 1
+            return sp.coo_matrix((data, (row, col)), shape=self.shape)
+
+        if (
+            str(jl.typeof(body.lvl).name.name) == "DenseLevel" and
+            str(jl.typeof(body.lvl.lvl).name.name) == "SparseListLevel"
+        ):
+            data = np.asarray(body.lvl.lvl.lvl.val)
+            indices = np.asarray(body.lvl.lvl.idx) - 1
+            indptr = np.asarray(body.lvl.lvl.ptr) - 1
+            sp_class = sp.csr_matrix if order == (1, 0) else sp.csc_matrix
+            return sp_class((data, indices, indptr), shape=self.shape)
+
+        raise ValueError("Invalid format. Tensor should be a COO, CSR or CSC.")
+
 
 def random(shape, density=0.01, random_state=None):
     args = [*shape, density]
@@ -430,9 +471,13 @@ def asarray(obj, /, *, dtype=None, format=None):
         if format == "coo":
             storage = Storage(SparseCOO(tensor.ndim, Element(tensor.fill_value)), order)
         elif format == "csr":
-            storage = Storage(Dense(SparseList(Element(tensor.fill_value))), order)
+            if order != (1, 0):
+                raise ValueError("Invalid order for csr")
+            storage = Storage(Dense(SparseList(Element(tensor.fill_value))), (2, 1))
         elif format == "csc":
-            storage = Storage(Dense(SparseList(Element(tensor.fill_value))), order)
+            if order != (0, 1):
+                raise ValueError("Invalid order for csc")
+            storage = Storage(Dense(SparseList(Element(tensor.fill_value))), (1, 2))
         elif format == "csf":
             storage = Element(tensor.fill_value)
             for _ in range(tensor.ndim - 1):

--- a/tests/test_scipy_constructors.py
+++ b/tests/test_scipy_constructors.py
@@ -33,3 +33,36 @@ def test_scipy_compressed2d(arr2d, cls):
     assert_equal(finch_arr.todense(), sp_arr.todense())
     new_arr = finch.permute_dims(finch_arr, (1, 0))
     assert_equal(new_arr.todense(), sp_arr.todense().transpose())
+
+
+@pytest.mark.parametrize(
+    "format_with_cls_with_order", [
+        ("coo", sp.coo_matrix, "C"),
+        ("coo", sp.coo_matrix, "F"),
+        ("csc", sp.csc_matrix, "F"),
+        ("csr", sp.csr_matrix, "C"),
+    ]
+)
+def test_to_scipy_sparse(format_with_cls_with_order):
+    format, sp_class, order = format_with_cls_with_order
+    np_arr = np.random.default_rng(0).random((4, 5))
+    np_arr = np.array(np_arr, order=order)
+
+    finch_arr = finch.asarray(np_arr, format=format)
+
+    actual = finch_arr.to_scipy_sparse()
+
+    assert isinstance(actual, sp_class)
+    assert_equal(actual.todense(), np_arr)
+
+
+def test_to_scipy_sparse_invalid_input():
+    finch_arr = finch.asarray(np.ones((3,3,3)), format="dense")
+
+    with pytest.raises(ValueError, match="Can only convert a 2-dimensional array"):
+        finch_arr.to_scipy_sparse()
+
+    finch_arr = finch.asarray(np.ones((3,4)), format="dense")
+
+    with pytest.raises(ValueError, match="Invalid format. Tensor should be a COO, CSR or CSC."):
+        finch_arr.to_scipy_sparse()

--- a/tests/test_scipy_constructors.py
+++ b/tests/test_scipy_constructors.py
@@ -64,5 +64,23 @@ def test_to_scipy_sparse_invalid_input():
 
     finch_arr = finch.asarray(np.ones((3,4)), format="dense")
 
-    with pytest.raises(ValueError, match="Invalid format. Tensor should be a COO, CSR or CSC."):
+    with pytest.raises(ValueError, match="Tensor can't be converted to scipy.sparse object"):
         finch_arr.to_scipy_sparse()
+
+
+@pytest.mark.parametrize(
+    "format_with_pattern",
+    [
+        ("coo", "SparseCOO"),
+        ("csr", "SparseList"),
+        ("csc", "SparseList"),
+        ("bsr", "SparseCOO"),
+        ("dok", "SparseCOO")
+    ],
+)
+def test_from_scipy_sparse(format_with_pattern):
+    format, pattern = format_with_pattern
+    sp_arr = sp.random(10, 5, density=0.1, format=format)
+
+    result = finch.Tensor.from_scipy_sparse(sp_arr)
+    assert pattern in str(result)


### PR DESCRIPTION
Hi @willow-ahrens @hameerabbasi,

This PR adds compat changes to make finch backend compatible with Scipy, sklearn, etc., by adding:
- `SparseArray` marker class that is already used by PyData backend and SciPy, to identify a `pydata/sparse` object.
- `Tensor.from_scipy_sparse()` to convert Finch tensor to SciPy object.
- `Tensor.to_scipy_sparse()` to convert SciPy object back to Finch tensor.

SciPy PR: https://github.com/scipy/scipy/pull/19796