### PR TITLE
FIX: Seed RNG correctly

### DIFF
--- a/src/finch/julia.py
+++ b/src/finch/julia.py
@@ -13,4 +13,4 @@ juliapkg.resolve()
 from juliacall import Main as jl  # noqa
 
 jl.seval("using Finch")
-jl.seval("using Random: default_rng")
+jl.seval("using Random")

--- a/src/finch/tensor.py
+++ b/src/finch/tensor.py
@@ -473,7 +473,8 @@ def random(shape, density=0.01, random_state=None):
             seed = random_state.integers(np.iinfo(np.int32).max)
         else:
             seed = random_state
-        rng = jl.default_rng(seed)
+        rng = jl.Random.default_rng()
+        jl.Random.seed_b(rng, seed)
         args = [rng] + args
     return Tensor(jl.fsprand(*args))
 

--- a/tests/test_sparse.py
+++ b/tests/test_sparse.py
@@ -145,6 +145,13 @@ def test_random(random_state):
 
     assert_equal(result.todense(), expected.todense())
 
+    # test reproducible runs
+    run1 = finch.random((20, 20), density=0.8, random_state=0)
+    run2 = finch.random((20, 20), density=0.8, random_state=0)
+    run3 = finch.random((20, 20), density=0.8, random_state=0)
+    assert_equal(run1.todense(), run2.todense())
+    assert_equal(run1.todense(), run3.todense())
+
 
 @pytest.mark.parametrize("order", ["C", "F"])
 @pytest.mark.parametrize("format", ["coo", "csr", "csc", "csf", "dense", None])


### PR DESCRIPTION
Hi @willow-ahrens @hameerabbasi,

As described in #33 `default_rng` requires `seed!` for reproducible runs. The test I added fails on `main`.

WDYT?