### PR TITLE
Use `jl.permutedims` in `permute_dims`

### DIFF
--- a/src/finch/tensor.py
+++ b/src/finch/tensor.py
@@ -323,7 +323,7 @@ class Tensor(_Display, SparseArray):
 
     def permute_dims(self, axes: tuple[int, ...]) -> "Tensor":
         axes = tuple(i + 1 for i in axes)
-        new_obj = jl.swizzle(self._obj, *axes)
+        new_obj = jl.permutedims(self._obj, axes)
         new_tensor = Tensor(new_obj)
         return new_tensor
 

--- a/tests/test_sparse.py
+++ b/tests/test_sparse.py
@@ -121,15 +121,23 @@ def test_permute_dims(arr3d, permutation, order):
 
     arr_finch = finch.Tensor(arr).to_device(storage)
 
-    actual = finch.permute_dims(arr_finch, permutation)
+    actual_eager_mode = finch.permute_dims(arr_finch, permutation)
+    actual_lazy_mode = finch.compute(
+        finch.permute_dims(finch.lazy(arr_finch), permutation)
+    )
     expected = np.transpose(arr, permutation)
 
-    assert_equal(actual.todense(), expected)
+    assert_equal(actual_eager_mode.todense(), expected)
+    assert_equal(actual_lazy_mode.todense(), expected)
 
-    actual = finch.permute_dims(actual, permutation)
+    actual_eager_mode = finch.permute_dims(actual_eager_mode, permutation)
+    actual_lazy_mode = finch.compute(
+        finch.permute_dims(finch.lazy(actual_lazy_mode), permutation)
+    )
     expected = np.transpose(expected, permutation)
 
-    assert_equal(actual.todense(), expected)
+    assert_equal(actual_eager_mode.todense(), expected)
+    assert_equal(actual_lazy_mode.todense(), expected)
 
 
 @pytest.mark.parametrize("order", ["C", "F"])


### PR DESCRIPTION
Hi @hameerabbasi @willow-ahrens,

This small fix makes `permute_dims` use `jl.permutedims` instead of `jl.swizzle`.

It's needed to make transpositions work in the lazy mode, because for `swizzle(lazy(tensor), ...)` we get:

```
ERROR: MethodError: swizzle(::Finch.LazyTensor{Float64, 3}, ::Int64, ::Int64, ::Int64) is ambiguous.

Candidates:
  swizzle(body, dims::Int64...)
    @ Finch ~/JuliaProjects/Finch.jl/src/tensors/combinators/swizzle.jl:80
  swizzle(arr::Finch.LazyTensor, dims...)
    @ Finch ~/JuliaProjects/Finch.jl/src/interface/lazy.jl:63
```

and `permutedims` doesn't raise it. 