### PR TITLE
Add `Finch.jl` package dev mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "finch-tensor"
-version = "0.1.17"
+version = "0.1.18"
 description = ""
 authors = ["Willow Ahrens <willow.marie.ahrens@gmail.com>"]
 readme = "README.md"

--- a/src/finch/julia.py
+++ b/src/finch/julia.py
@@ -1,11 +1,18 @@
+import os
+
 import juliapkg
 
+_FINCH_NAME = "Finch"
 _FINCH_VERSION = "0.6.25"
 _FINCH_HASH = "9177782c-1635-4eb9-9bfb-d9dfa25e6bce"
+_FINCH_REPO_PATH = os.environ.get("FINCH_REPO_PATH", default=None)
 
-deps = juliapkg.deps.load_cur_deps()
-if deps.get("packages", {}).get("Finch", {}).get("version", None) != _FINCH_VERSION:
-    juliapkg.add("Finch", _FINCH_HASH, version=_FINCH_VERSION)
+if _FINCH_REPO_PATH:  # Also account for empty string
+    juliapkg.add(_FINCH_NAME, _FINCH_HASH, path=_FINCH_REPO_PATH, dev=True)
+else:
+    deps = juliapkg.deps.load_cur_deps()
+    if deps.get("packages", {}).get(_FINCH_NAME, {}).get("version", None) != _FINCH_VERSION:
+        juliapkg.add(_FINCH_NAME, _FINCH_HASH, version=_FINCH_VERSION)
 
 import juliacall  # noqa
 


### PR DESCRIPTION
Hi @hameerabbasi @hameerabbasi,

To run `finch-tensor` test in `Finch.jl` to catch regressions we need a dev mode in `finch-tensor` (Also, I find it useful for local development when I want to test `finch-tensor` against unreleased Finch codebase).

Connected to https://github.com/willow-ahrens/Finch.jl/issues/539