### PR TITLE
Array API support - continuation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "finch-tensor"
-version = "0.1.19"
+version = "0.1.20"
 description = ""
 authors = ["Willow Ahrens <willow.marie.ahrens@gmail.com>"]
 readme = "README.md"

--- a/src/finch/__init__.py
+++ b/src/finch/__init__.py
@@ -15,8 +15,21 @@ from operator import (
     and_ as bitwise_and,
     lshift as bitwise_left_shift,
     rshift as bitwise_right_shift,
+    eq as equal,
+    ne as not_equal,
+    lt as less,
+    le as less_equal,
+    gt as greater,
+    ge as greater_equal,
+    mod as remainder,
 )
-
+from numpy import (
+    e as e,
+    pi as pi,
+    inf as inf,
+    nan as nan,
+    newaxis as newaxis,
+)
 from .levels import (
     Dense,
     Element,
@@ -77,6 +90,16 @@ from .tensor import (
     ones_like,
     zeros,
     zeros_like,
+    isnan,
+    isfinite,
+    isinf,
+    reshape,
+    square,
+    logaddexp,
+    trunc,
+    logical_and,
+    logical_or,
+    logical_xor,
 )
 from .compiled import (
     lazy,
@@ -100,6 +123,9 @@ from .dtypes import (
     complex64,
     complex128,
     bool,
+    finfo,
+    iinfo,
+    can_cast,
 )
 
 __all__ = [
@@ -195,4 +221,31 @@ __all__ = [
     "bitwise_right_shift",
     "bitwise_xor",
     "bitwise_invert",
+    "finfo",
+    "iinfo",
+    "isnan",
+    "isinf",
+    "isfinite",
+    "reshape",
+    "equal",
+    "not_equal",
+    "less",
+    "less_equal",
+    "greater",
+    "greater_equal",
+    "square",
+    "logaddexp",
+    "logical_and",
+    "logical_or",
+    "logical_xor",
+    "trunc",
+    "e",
+    "pi",
+    "inf",
+    "nan",
+    "newaxis",
+    "can_cast",
+    "remainder",
 ]
+
+__array_api_version__: str = "2023.12"

--- a/src/finch/dtypes.py
+++ b/src/finch/dtypes.py
@@ -1,3 +1,5 @@
+import builtins
+
 import numpy as np
 
 from .julia import jl
@@ -31,6 +33,7 @@ jl_to_np_dtype = {
     int16: np.int16,
     int32: np.int32,
     int64: np.int64,
+    uint: np.uint,
     uint8: np.uint8,
     uint16: np.uint16,
     uint32: np.uint32,
@@ -40,6 +43,17 @@ jl_to_np_dtype = {
     float64: np.float64,
     complex64: np.complex64,
     complex128: np.complex128,
-    bool: np.bool_,
+    bool: builtins.bool,
     None: None,
 }
+
+def finfo(dtype):
+    return np.finfo(jl_to_np_dtype[dtype])
+
+def iinfo(dtype):
+    return np.iinfo(jl_to_np_dtype[dtype])
+
+def can_cast(from_, to, /) -> builtins.bool:
+    if hasattr(from_, "dtype"):
+        from_ = from_.dtype
+    return np.can_cast(jl_to_np_dtype[from_], jl_to_np_dtype[to])

--- a/src/finch/errors.py
+++ b/src/finch/errors.py
@@ -1,0 +1,3 @@
+
+class PerformanceWarning(Warning):
+    pass

--- a/src/finch/julia.py
+++ b/src/finch/julia.py
@@ -3,7 +3,7 @@ import os
 import juliapkg
 
 _FINCH_NAME = "Finch"
-_FINCH_VERSION = "0.6.26"
+_FINCH_VERSION = "0.6.27"
 _FINCH_HASH = "9177782c-1635-4eb9-9bfb-d9dfa25e6bce"
 _FINCH_REPO_PATH = os.environ.get("FINCH_REPO_PATH", default=None)
 

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -59,6 +59,11 @@ def test_lazy_mode(arr3d):
         "expm1",
         "floor",
         "ceil",
+        "isnan",
+        "isfinite",
+        "isinf",
+        "square",
+        "trunc",
     ],
 )
 def test_elemwise_ops_1_arg(arr3d, func_name):
@@ -82,6 +87,24 @@ def test_elemwise_tensor_ops_1_arg(arr3d, meth_name):
     expected = getattr(arr3d, meth_name)()
 
     assert_equal(actual.todense(), expected)
+
+
+@pytest.mark.parametrize(
+    "func_name",
+    ["logaddexp", "logical_and", "logical_or", "logical_xor"],
+)
+def test_elemwise_ops_2_args(arr3d, func_name):
+    arr2d = np.array([[0, 3, 2, 0], [0, 0, 3, 2]])
+    if func_name.startswith("logical"):
+        arr3d = arr3d.astype(bool)
+        arr2d = arr2d.astype(bool)
+    A_finch = finch.Tensor(arr3d)
+    B_finch = finch.Tensor(arr2d)
+
+    actual = getattr(finch, func_name)(A_finch, B_finch)
+    expected = getattr(np, func_name)(arr3d, arr2d)
+
+    assert_allclose(actual.todense(), expected)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Hi @hameerabbasi,

This PR add a couple of simple Array API functions:
```
    "finfo",  # ported from numpy
    "iinfo",  # ported from numpy
    "isnan",  # the rest is just element-wise functions
    "isinf",
    "isfinite",
    "equal",
    "not_equal",
    "less",
    "less_equal",
    "greater",
    "greater_equal",
    "square",
    "logaddexp",
    "logical_and",
    "logical_or",
    "logical_xor",
    "trunc",
```
Adds `__bool__`, etc. to `Tensor` class.

It also introduces a few modifications to correctly run `array-api-test` suite.

---

The tricky part is `reshape` which we don't have right now but it's required by most of `array-api-tests` suites to even run them.
Maybe one option could be another env var `TEST_MODE` that when set enables temporary implementation (that moves to numpy, reshapes, and moves back to Tensor). Otherwise `NotImplementedError` is raised. WDYT?