### PR TITLE
Adjustments for `Finch.jl#562`

### DIFF
--- a/src/finch/julia.py
+++ b/src/finch/julia.py
@@ -3,7 +3,7 @@ import os
 import juliapkg
 
 _FINCH_NAME = "Finch"
-_FINCH_VERSION = "0.6.28"
+_FINCH_VERSION = "0.6.29"
 _FINCH_HASH = "9177782c-1635-4eb9-9bfb-d9dfa25e6bce"
 _FINCH_REPO_PATH = os.environ.get("FINCH_REPO_PATH", default=None)
 

--- a/src/finch/tensor.py
+++ b/src/finch/tensor.py
@@ -742,7 +742,11 @@ def _reduce(x: Tensor, fn: Callable, axis, dtype=None):
     else:
         result = fn(x._obj)
 
-    if jl.isa(result, jl.Finch.Tensor) or jl.isa(result, jl.Finch.LazyTensor):
+    if (
+        jl.isa(result, jl.Finch.SwizzleArray) or
+        jl.isa(result, jl.Finch.Tensor) or
+        jl.isa(result, jl.Finch.LazyTensor)
+    ):
         result = Tensor(result)
     else:
         result = np.array(result)


### PR DESCRIPTION
Hi @willow-ahrens,

Here's a PR with adjustments required by https://github.com/willow-ahrens/Finch.jl/pull/562.

One thing that I'm concerned about is reduced performance of code that uses `PlusOneVector` (zero-copy SciPy constructors), which is **way slower** than copy counterparts. 

For example, in SDDMM, changing copy to no-copy CSR matrix introduces x10 speed reduction.