### PR TITLE
 `scipy.sparse` fill-value fix.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "finch-tensor"
-version = "0.1.22"
+version = "0.1.23"
 description = ""
 authors = ["Willow Ahrens <willow.marie.ahrens@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
Hi @hameerabbasi,

This PR adds support for `fill_value/allowed_fill_values` in `to_scipy_sparse` and `from_scipy_sparse`.
