### PR TITLE
Adjust `dtype` conversions

### DIFF
--- a/src/finch/julia.py
+++ b/src/finch/julia.py
@@ -17,7 +17,7 @@ else:
     ):
         juliapkg.add(_FINCH_NAME, _FINCH_HASH, version=_FINCH_VERSION)
 
-import juliacall  # noqa
+import juliacall as jc  # noqa
 
 juliapkg.resolve()
 from juliacall import Main as jl  # noqa

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -167,10 +167,7 @@ def test_reductions(arr3d, func_name, axis, dtype):
     actual = getattr(finch, func_name)(A_finch, axis=axis)
     expected = getattr(np, func_name)(arr3d, axis=axis)
 
-    if isinstance(actual, finch.Tensor):
-        actual = actual.todense()
-
-    assert_equal(actual, expected)
+    assert_equal(actual.todense(), expected)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_sparse.py
+++ b/tests/test_sparse.py
@@ -142,7 +142,7 @@ def test_permute_dims(arr3d, permutation, order):
 
 @pytest.mark.parametrize("order", ["C", "F"])
 def test_astype(arr3d, order):
-    arr = np.array(arr3d, order=order)
+    arr = np.array(arr3d, order=order, dtype=np.int64)
     storage = finch.Storage(
         finch.Dense(finch.SparseList(finch.SparseList(finch.Element(np.int64(0))))),
         order=order,
@@ -150,15 +150,21 @@ def test_astype(arr3d, order):
     arr_finch = finch.Tensor(arr).to_device(storage)
 
     result = finch.astype(arr_finch, finch.int64)
-    assert_equal(result.todense(), arr)
-    assert not arr_finch is result
+    assert not result is arr_finch
+    result = result.todense()
+    assert_equal(result, arr)
+    assert result.dtype == arr.dtype
 
     result = finch.astype(arr_finch, finch.int64, copy=False)
-    assert_equal(result.todense(), arr)
-    assert arr_finch is result
+    assert result is arr_finch
+    result = result.todense()
+    assert_equal(result, arr)
+    assert result.dtype == arr.dtype
 
-    result = finch.astype(arr_finch, finch.float32)
-    assert_equal(result.todense(), arr.astype(np.float32))
+    result = finch.astype(arr_finch, finch.float32).todense()
+    arr = arr.astype(np.float32)
+    assert_equal(result, arr)
+    assert result.dtype == arr.dtype
 
     with pytest.raises(
         ValueError, match="Unable to avoid a copy while casting in no-copy mode."


### PR DESCRIPTION
Hi @hameerabbasi,

This PR:
- makes sure reduction functions always return Tensor (even for 0-D output)
- now `finch.astype` works correctly (it turns out that Tensors had correct dtypes but `todense()` returned invalid ones due to Julia->Python implicit scalar conversion https://github.com/JuliaPy/PythonCall.jl/issues/504#issuecomment-2133497733)

Both of them fix some array-api-tests xfails. 