### PR TITLE
Non-boolean dtypes support for `finch.any` and `finch.all`

### DIFF
--- a/src/finch/tensor.py
+++ b/src/finch/tensor.py
@@ -837,7 +837,7 @@ def any(
     axis: int | tuple[int, ...] | None = None,
     keepdims: bool = False,
 ) -> Tensor:
-    return _reduce(x, jl.any, axis)
+    return _reduce(x != 0, jl.any, axis)
 
 
 def all(
@@ -847,7 +847,7 @@ def all(
     axis: int | tuple[int, ...] | None = None,
     keepdims: bool = False,
 ) -> Tensor:
-    return _reduce(x, jl.all, axis)
+    return _reduce(x != 0, jl.all, axis)
 
 
 def eye(

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -160,8 +160,6 @@ def test_elemwise_tensor_ops_2_args(arr3d, meth_name):
 @pytest.mark.parametrize("axis", [None, -1, 1, (0, 1), (0, 1, 2)])
 @pytest.mark.parametrize("dtype", [None])  # not supported yet
 def test_reductions(arr3d, func_name, axis, dtype):
-    if func_name in ("any", "all"):
-        arr3d = arr3d.astype(bool)
     A_finch = finch.Tensor(arr3d)
 
     actual = getattr(finch, func_name)(A_finch, axis=axis)


### PR DESCRIPTION
Hi @hameerabbasi,

This change allows passing non-boolean tensors to `finch.any` and `finch.all`, as proposed [here](https://github.com/willow-ahrens/Finch.jl/issues/575#issuecomment-2142522238).

It removes:
```
array_api_tests/test_utility_functions.py::test_all
array_api_tests/test_utility_functions.py::test_any
```
from `Finch-array-api-xfails.txt`
