### PR TITLE
Refine `dtype` argument for `sum` and `prod`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "finch-tensor"
-version = "0.1.24"
+version = "0.1.25"
 description = ""
 authors = ["Willow Ahrens <willow.marie.ahrens@gmail.com>"]
 readme = "README.md"

--- a/src/finch/tensor.py
+++ b/src/finch/tensor.py
@@ -778,14 +778,56 @@ def nonzero(x: Tensor, /) -> tuple[np.ndarray, ...]:
     return tuple(Tensor(i[sort_order]) for i in indices)
 
 
-def _reduce(x: Tensor, fn: Callable, axis, dtype=None):
+def _reduce_core(x: Tensor, fn: Callable, axis: int | tuple[int, ...] | None):
     if axis is not None:
         axis = normalize_axis_tuple(axis, x.ndim)
         axis = tuple(i + 1 for i in axis)
         result = fn(x._obj, dims=axis)
     else:
         result = fn(x._obj)
+    return result
 
+
+def _reduce_sum_prod(
+    x: Tensor,
+    fn: Callable,
+    axis: int | tuple[int, ...] | None,
+    dtype: DType | None,
+) -> Tensor:
+    result = _reduce_core(x, fn, axis)
+
+    if np.isscalar(result):
+        if jl.seval(f"{x.dtype} <: Integer"):
+            tmp_dtype = jl_dtypes.int_
+        else:
+            tmp_dtype = x.dtype
+        result = jl.Tensor(
+            jl.Element(
+                jc.convert(tmp_dtype, 0),
+                np.array(result, dtype=jl_dtypes.jl_to_np_dtype[tmp_dtype])
+            )
+        )
+
+    result = Tensor(result)
+
+    if jl.isa(result._obj, jl.Finch.LazyTensor):
+        if dtype is not None:
+            raise ValueError(
+                "`dtype` keyword for `sum` and `prod` in the lazy mode isn't supported"
+            )
+    # dtype casting rules
+    elif dtype is not None:
+        result = astype(result, dtype, copy=None)
+    elif jl.seval(f"{x.dtype} <: Unsigned"):
+        result = astype(result, jl_dtypes.uint, copy=None)
+    elif jl.seval(f"{x.dtype} <: Signed"):
+        result = astype(result, jl_dtypes.int_, copy=None)
+
+    return result
+
+
+def _reduce(x: Tensor, fn: Callable, axis: int | tuple[int, ...] | None):
+    result = _reduce_core(x, fn, axis)
     if np.isscalar(result):
         result = jl.Tensor(
             jl.Element(
@@ -793,22 +835,7 @@ def _reduce(x: Tensor, fn: Callable, axis, dtype=None):
                 np.array(result, dtype=jl_dtypes.jl_to_np_dtype[x.dtype])
             )
         )
-
-    result = Tensor(result)
-    if dtype != "skip":
-        if jl.isa(result._obj, jl.Finch.LazyTensor):
-            if dtype is not None:
-                raise ValueError(
-                    "`dtype` keyword for `sum` and `prod` in the lazy mode isn't supported"
-                )
-        # dtype casting rules for `sum` and `prod`
-        elif dtype is not None:
-            result = astype(result, dtype, copy=None)
-        elif jl.seval(f"{x.dtype} <: Unsigned"):
-            result = astype(result, jl_dtypes.uint, copy=None)
-        elif jl.seval(f"{x.dtype} <: Signed"):
-            result = astype(result, jl_dtypes.int_, copy=None)
-    return result
+    return Tensor(result)
 
 
 def sum(
@@ -819,7 +846,7 @@ def sum(
     dtype: DType | None = None,
     keepdims: bool = False,
 ) -> Tensor:
-    return _reduce(x, jl.sum, axis, dtype)
+    return _reduce_sum_prod(x, jl.sum, axis, dtype)
 
 
 def prod(
@@ -830,7 +857,7 @@ def prod(
     dtype: DType | None = None,
     keepdims: bool = False,
 ) -> Tensor:
-    return _reduce(x, jl.prod, axis, dtype)
+    return _reduce_sum_prod(x, jl.prod, axis, dtype)
 
 
 def max(
@@ -840,7 +867,7 @@ def max(
     axis: int | tuple[int, ...] | None = None,
     keepdims: bool = False,
 ) -> Tensor:
-    return _reduce(x, jl.maximum, axis, dtype="skip")
+    return _reduce(x, jl.maximum, axis)
 
 
 def min(
@@ -850,7 +877,7 @@ def min(
     axis: int | tuple[int, ...] | None = None,
     keepdims: bool = False,
 ) -> Tensor:
-    return _reduce(x, jl.minimum, axis, dtype="skip")
+    return _reduce(x, jl.minimum, axis)
 
 
 def any(
@@ -860,7 +887,7 @@ def any(
     axis: int | tuple[int, ...] | None = None,
     keepdims: bool = False,
 ) -> Tensor:
-    return _reduce(x != 0, jl.any, axis, dtype="skip")
+    return _reduce(x != 0, jl.any, axis)
 
 
 def all(
@@ -870,7 +897,7 @@ def all(
     axis: int | tuple[int, ...] | None = None,
     keepdims: bool = False,
 ) -> Tensor:
-    return _reduce(x != 0, jl.all, axis, dtype="skip")
+    return _reduce(x != 0, jl.all, axis)
 
 
 def eye(

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -158,14 +158,33 @@ def test_elemwise_tensor_ops_2_args(arr3d, meth_name):
 
 @pytest.mark.parametrize("func_name", ["sum", "prod", "max", "min", "any", "all"])
 @pytest.mark.parametrize("axis", [None, -1, 1, (0, 1), (0, 1, 2)])
-@pytest.mark.parametrize("dtype", [None])  # not supported yet
-def test_reductions(arr3d, func_name, axis, dtype):
+def test_reductions(arr3d, func_name, axis):
     A_finch = finch.Tensor(arr3d)
 
     actual = getattr(finch, func_name)(A_finch, axis=axis)
     expected = getattr(np, func_name)(arr3d, axis=axis)
 
     assert_equal(actual.todense(), expected)
+
+
+@pytest.mark.parametrize("func_name", ["sum", "prod"])
+@pytest.mark.parametrize("axis", [None, 0, 1])
+@pytest.mark.parametrize(
+    "in_dtype, dtype, expected_dtype",
+    [
+        (finch.int64, None, np.int64),
+        (finch.int16, None, np.int64),
+        (finch.uint8, None, np.uint64),
+        (finch.int64, finch.float32, np.float32),
+        (finch.float64, finch.complex128, np.complex128),
+    ],
+)
+def test_sum_prod_dtype_arg(arr3d, func_name, axis, in_dtype, dtype, expected_dtype):
+    arr_finch = finch.asarray(np.abs(arr3d), dtype=in_dtype)
+
+    actual = getattr(finch, func_name)(arr_finch, axis=axis, dtype=dtype).todense()
+
+    assert actual.dtype == expected_dtype
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Hi @hameerabbasi @willow-ahrens,

This PR adds proper support for the `dtype` argument for `finch.sum` and `finch.prod`.

It follows [Array API standard rules](https://data-apis.org/array-api/latest/API_specification/generated/array_api.sum.html), specifically for integer dtypes (there's a promotion rule saying that for `dtype=None` signed and unsigned dtypes should be promoted to the default (signed or unsigned) integer).

`_reduce` also makes sure that scalars returned from Julia (when `axis=None`, so it sums to a scalar) have the correct dtype. This turned out to be a bit tricky. If we're summing `Int8` Tensor the scalar result is returned as a Python builtin (so e.g. int64) so dtype is "erased" when Julia returns the result of e.g. `jl.sum`. To recreate Finch Tensor 0D array/scalar with the correct dtype I did:
```python
if np.isscalar(result):
    result = jl.Tensor(
        jl.Element(
            jc.convert(x.dtype, 0),
            np.array(result, dtype=jl_dtypes.jl_to_np_dtype[x.dtype])
        )
    )
```
Which is a bit cumbersome but it works. 