### PR TITLE
Add `device` and `to_device`. Python scalars casting.

### DIFF
--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -98,7 +98,7 @@ def test_indexing_2d(arr2d, index, order):
 def test_indexing_3d(arr3d, index, levels_descr, order):
     arr = np.array(arr3d, order=order)
     storage = finch.Storage(levels_descr, order=order)
-    arr_finch = finch.Tensor(arr).to_device(storage)
+    arr_finch = finch.Tensor(arr).to_storage(storage)
 
     actual = arr_finch[index]
     expected = arr[index]

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -210,9 +210,9 @@ def test_tensordot(arr3d, storage):
     B_finch = finch.Tensor(arr2d)
     C_finch = finch.Tensor(arr3d)
     if storage is not None:
-        A_finch = A_finch.to_device(storage[0])
-        B_finch = B_finch.to_device(storage[1])
-        C_finch = C_finch.to_device(storage[2])
+        A_finch = A_finch.to_storage(storage[0])
+        B_finch = B_finch.to_storage(storage[1])
+        C_finch = C_finch.to_storage(storage[2])
 
     actual = finch.tensordot(B_finch, B_finch)
     expected = np.tensordot(arr2d, arr2d)

--- a/tests/test_sparse.py
+++ b/tests/test_sparse.py
@@ -25,7 +25,7 @@ def test_wrappers(dtype, jl_dtype, order):
         finch.Dense(finch.SparseList(finch.SparseList(finch.Element(dtype(0.0))))),
         order=order,
     )
-    B_finch = B_finch.to_device(storage)
+    B_finch = B_finch.to_storage(storage)
 
     assert B_finch.shape == B.shape
     assert B_finch.dtype == jl_dtype
@@ -34,7 +34,7 @@ def test_wrappers(dtype, jl_dtype, order):
     storage = finch.Storage(
         finch.Dense(finch.Dense(finch.Element(dtype(1.0)))), order=order
     )
-    A_finch = finch.Tensor(A).to_device(storage)
+    A_finch = finch.Tensor(A).to_storage(storage)
 
     assert A_finch.shape == A.shape
     assert A_finch.dtype == jl_dtype
@@ -119,7 +119,7 @@ def test_permute_dims(arr3d, permutation, order):
         finch.Dense(finch.SparseList(finch.SparseList(finch.Element(0)))), order=order
     )
 
-    arr_finch = finch.Tensor(arr).to_device(storage)
+    arr_finch = finch.Tensor(arr).to_storage(storage)
 
     actual_eager_mode = finch.permute_dims(arr_finch, permutation)
     actual_lazy_mode = finch.compute(
@@ -147,7 +147,7 @@ def test_astype(arr3d, order):
         finch.Dense(finch.SparseList(finch.SparseList(finch.Element(np.int64(0))))),
         order=order,
     )
-    arr_finch = finch.Tensor(arr).to_device(storage)
+    arr_finch = finch.Tensor(arr).to_storage(storage)
 
     result = finch.astype(arr_finch, finch.int64)
     assert not result is arr_finch


### PR DESCRIPTION
Hi @hameerabbasi,

This PR introduces changes that we discussed some time ago: renames current `to_device()` to `to_storage()` used for changing the storage, and introduces Array API compatible `to_device()` and `device` property (also needed for `array-api-tests`). 

There's also a small fix for avoiding unwanted type promotion when executing: `Tensor + python scalar` to align with Array API. 