### PR TITLE
Enable Finch dependency from url

### DIFF
--- a/src/finch/julia.py
+++ b/src/finch/julia.py
@@ -6,9 +6,15 @@ _FINCH_NAME = "Finch"
 _FINCH_VERSION = "0.6.31"
 _FINCH_HASH = "9177782c-1635-4eb9-9bfb-d9dfa25e6bce"
 _FINCH_REPO_PATH = os.environ.get("FINCH_REPO_PATH", default=None)
+_FINCH_REPO_URL = os.environ.get("FINCH_URL_PATH", default=None)
+
+if _FINCH_REPO_PATH and _FINCH_REPO_URL:
+    raise ValueError("FINCH_REPO_PATH and FINCH_URL_PATH can't be set at the same time.")
 
 if _FINCH_REPO_PATH:  # Also account for empty string
     juliapkg.add(_FINCH_NAME, _FINCH_HASH, path=_FINCH_REPO_PATH, dev=True)
+elif _FINCH_REPO_URL:
+    juliapkg.add(_FINCH_NAME, _FINCH_HASH, url=_FINCH_REPO_URL, dev=True)
 else:
     deps = juliapkg.deps.load_cur_deps()
     if (

--- a/src/finch/tensor.py
+++ b/src/finch/tensor.py
@@ -85,7 +85,7 @@ class Tensor(_Display, SparseArray):
 
     def __init__(
         self,
-        obj: np.ndarray | spmatrix | Storage | JuliaObj | "Tensor",
+        obj: np.ndarray | spmatrix | Storage | JuliaObj,
         /,
         *,
         fill_value: np.number | None = None,

--- a/src/finch/tensor.py
+++ b/src/finch/tensor.py
@@ -85,7 +85,7 @@ class Tensor(_Display, SparseArray):
 
     def __init__(
         self,
-        obj: np.ndarray | spmatrix | Storage | JuliaObj,
+        obj: np.ndarray | spmatrix | Storage | JuliaObj | "Tensor",
         /,
         *,
         fill_value: np.number | None = None,
@@ -985,6 +985,10 @@ def eye(
 
 
 def tensordot(x1: Tensor, x2: Tensor, /, *, axes=2) -> Tensor:
+    if not isinstance(x1, Tensor):
+        x1 = Tensor(x1)
+    if not isinstance(x2, Tensor):
+        x2 = Tensor(x2)
     if isinstance(axes, Iterable):
         self_axes = normalize_axis_tuple(axes[0], x1.ndim)
         other_axes = normalize_axis_tuple(axes[1], x2.ndim)


### PR DESCRIPTION
Hi @hameerabbasi,

This change allows to use `finch-tensor` with the latest `main` Finch.jl without a local copy. 