### PR TITLE
 MAINT: Refine order support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "finch-tensor"
-version = "0.1.30"
+version = "0.1.31"
 description = ""
 authors = ["Willow Ahrens <willow.marie.ahrens@gmail.com>"]
 readme = "README.md"

--- a/src/finch/tensor.py
+++ b/src/finch/tensor.py
@@ -388,7 +388,7 @@ class Tensor(_Display, SparseArray):
         result = jl.copyto_b(
             jl.swizzle(jl.Tensor(storage.levels_descr._obj), *order), tensor._obj
         )
-        return jl.dropfills(result)
+        return jl.dropfills(result) if tensor._is_dense else result
 
     @classmethod
     def _from_numpy(cls, arr: np.ndarray, fill_value: np.number, copy: bool | None = None) -> JuliaObj:

--- a/src/finch/tensor.py
+++ b/src/finch/tensor.py
@@ -383,11 +383,12 @@ class Tensor(_Display, SparseArray):
         return Tensor(self._from_other_tensor(self, storage=storage))
 
     @classmethod
-    def _from_other_tensor(cls, tensor: "Tensor", storage: Storage | None) -> JuliaObj:
+    def _from_other_tensor(cls, tensor: "Tensor", storage: Storage) -> JuliaObj:
         order = cls.preprocess_order(storage.order, tensor.ndim)
-        return jl.swizzle(
-            jl.Tensor(storage.levels_descr._obj, tensor._obj.body), *order
+        result = jl.copyto_b(
+            jl.swizzle(jl.Tensor(storage.levels_descr._obj), *order), tensor._obj
         )
+        return jl.dropfills(result)
 
     @classmethod
     def _from_numpy(cls, arr: np.ndarray, fill_value: np.number, copy: bool | None = None) -> JuliaObj:
@@ -664,12 +665,8 @@ def asarray(
         if format == "coo":
             storage = Storage(SparseCOO(tensor.ndim, Element(tensor.fill_value)), order)
         elif format == "csr":
-            if order != (1, 0):
-                raise ValueError("Invalid order for csr")
             storage = Storage(Dense(SparseList(Element(tensor.fill_value))), (2, 1))
         elif format == "csc":
-            if order != (0, 1):
-                raise ValueError("Invalid order for csc")
             storage = Storage(Dense(SparseList(Element(tensor.fill_value))), (1, 2))
         elif format == "csf":
             storage = Element(tensor.fill_value)

--- a/tests/test_sparse.py
+++ b/tests/test_sparse.py
@@ -197,12 +197,8 @@ def test_asarray(arr2d, arr3d, order, format):
     arr = np.array(arr, order=order)
     arr_finch = finch.Tensor(arr)
 
-    if (format, order) in [("csr", "F"), ("csc", "C")]:
-        with pytest.raises(ValueError, match="Invalid order for (csr|csc)"):
-            finch.asarray(arr_finch, format=format)
-    else:
-        result = finch.asarray(arr_finch, format=format)
-        assert_equal(result.todense(), arr)
+    result = finch.asarray(arr_finch, format=format)
+    assert_equal(result.todense(), arr)
 
 
 @pytest.mark.parametrize(
@@ -302,8 +298,6 @@ def test_where(order_and_format):
 )
 def test_nonzero(order, format_shape):
     format, shape = format_shape
-    if (format, order) in [("csr", "F"), ("csc", "C")]:
-        pytest.skip("invalid format+order")
     rng = np.random.default_rng(0)
     arr = rng.random(shape)
     arr = np.array(arr, order=order)


### PR DESCRIPTION
Hi @willow-ahrens @hameerabbasi,

This PR refines order support, by allowing `finch.asarray(any_input, format=any_format)` regardless of `any_input` order.

Right now it's accomplished by calling `copyto!` and then `dropfills` which I think performs copy twice. Could it be achieved with a one function call? (or performing one copy)

- `copyto!` for dense source and sparse (e.g. `csr`) destination copies all elements including fill values as non-fill ones (therefore it requires `dropfills`)
- calling only `dropfills!` fails for `csr` format as shown here https://github.com/willow-ahrens/Finch.jl/issues/609#issuecomment-2186636101