### PR TITLE
Add Galley option to compute()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ pre-commit = "^3.6.0"
 pytest-cov = "^4.1.0"
 sparse = "^0.15.1"
 scipy = "^1.7"
-numba = ">=0.55.0"
+numba = ">=0.55.0,<0.61.0rc1"
+llvmlite = "<0.44.0rc1"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "finch-tensor"
-version = "0.1.35"
+version = "0.2.0"
 description = ""
 authors = ["Willow Ahrens <willow.marie.ahrens@gmail.com>"]
 readme = "README.md"

--- a/src/finch/__init__.py
+++ b/src/finch/__init__.py
@@ -112,6 +112,7 @@ from .compiled import (
     lazy,
     compiled,
     compute,
+    set_optimizer
 )
 from .dtypes import (
     int_,

--- a/src/finch/__init__.py
+++ b/src/finch/__init__.py
@@ -112,7 +112,8 @@ from .compiled import (
     lazy,
     compiled,
     compute,
-    set_optimizer
+    set_optimizer,
+    clear_optimizer_cache
 )
 from .dtypes import (
     int_,

--- a/src/finch/__init__.py
+++ b/src/finch/__init__.py
@@ -113,7 +113,6 @@ from .compiled import (
     compiled,
     compute,
     set_optimizer,
-    clear_optimizer_cache
 )
 from .dtypes import (
     int_,

--- a/src/finch/__init__.py
+++ b/src/finch/__init__.py
@@ -113,6 +113,8 @@ from .compiled import (
     compiled,
     compute,
     set_optimizer,
+    DefaultScheduler,
+    GalleyScheduler,
 )
 from .dtypes import (
     int_,

--- a/src/finch/compiled.py
+++ b/src/finch/compiled.py
@@ -27,8 +27,18 @@ def lazy(tensor: Tensor):
         return Tensor(jl.Finch.LazyTensor(tensor._obj))
     return tensor
 
+def set_optimizer(opt="default"):
+    if opt == "default":
+        jl.Finch.set_scheduler_b(jl.Finch.default_scheduler())
+    elif opt == "galley":
+        jl.Finch.set_scheduler_b(jl.Finch.galley_scheduler())
+    return
 
-def compute(tensor: Tensor, *, verbose: bool = False):
+
+def compute(tensor: Tensor, *, verbose: bool = False, opt="default"):
     if not tensor.is_computed():
-        return Tensor(jl.Finch.compute(tensor._obj, verbose=verbose))
+        if opt == "default":
+            return Tensor(jl.Finch.compute(tensor._obj, verbose=verbose))
+        elif opt == "galley":
+            return Tensor(jl.Finch.compute(tensor._obj, verbose=verbose, ctx=jl.Finch.galley_scheduler()))
     return tensor

--- a/src/finch/compiled.py
+++ b/src/finch/compiled.py
@@ -34,11 +34,16 @@ def set_optimizer(opt="default"):
         jl.Finch.set_scheduler_b(jl.Finch.galley_scheduler())
     return
 
+def clear_optimizer_cache():
+    jl.empty_b(jl.Finch.codes)
+    return
 
-def compute(tensor: Tensor, *, verbose: bool = False, opt="default"):
+def compute(tensor: Tensor, *, verbose: bool = False, opt=""):
     if not tensor.is_computed():
-        if opt == "default":
+        if opt == "":
             return Tensor(jl.Finch.compute(tensor._obj, verbose=verbose))
+        elif opt == "default":
+            return Tensor(jl.Finch.compute(tensor._obj, verbose=verbose, ctx=jl.Finch.default_scheduler()))
         elif opt == "galley":
-            return Tensor(jl.Finch.compute(tensor._obj, verbose=verbose, ctx=jl.Finch.galley_scheduler()))
+            return Tensor(jl.Finch.compute(tensor._obj, verbose=verbose, ctx=jl.Finch.galley_scheduler(verbose=verbose)))
     return tensor

--- a/src/finch/compiled.py
+++ b/src/finch/compiled.py
@@ -4,7 +4,7 @@ from .julia import jl
 from .tensor import Tensor
 
 
-def compiled(func):
+def compiled(func, opt="galley"):
     @wraps(func)
     def wrapper_func(*args, **kwargs):
         new_args = []
@@ -15,7 +15,7 @@ def compiled(func):
                 new_args.append(arg)
 
         result = func(*new_args, **kwargs)
-        result_tensor = Tensor(jl.Finch.compute(result._obj))
+        result_tensor = Tensor(jl.Finch.compute(result._obj, opt=opt))
 
         return result_tensor
 

--- a/src/finch/compiled.py
+++ b/src/finch/compiled.py
@@ -4,23 +4,29 @@ from .julia import jl
 from .tensor import Tensor
 
 
-def compiled(func, opt="galley"):
-    @wraps(func)
-    def wrapper_func(*args, **kwargs):
-        new_args = []
-        for arg in args:
-            if isinstance(arg, Tensor) and not jl.isa(arg._obj, jl.Finch.LazyTensor):
-                new_args.append(Tensor(jl.Finch.LazyTensor(arg._obj)))
-            else:
-                new_args.append(arg)
+def get_scheduler(name, verbose=False):
+    if name == "default":
+        return jl.Finch.default_scheduler()
+    elif name == "galley":
+        return jl.Finch.galley_scheduler(verbose=verbose)
 
-        result = func(*new_args, **kwargs)
-        result_tensor = compute(result, opt=opt)
+def compiled(opt=""):
+    def inner(func):  
+        @wraps(func)  
+        def wrapper_func(*args, **kwargs):  
+            new_args = []  
+            for arg in args:  
+                if isinstance(arg, Tensor) and not jl.isa(arg._obj, jl.Finch.LazyTensor):  
+                    new_args.append(Tensor(jl.Finch.LazyTensor(arg._obj)))  
+                else:  
+                    new_args.append(arg)  
+            result = func(*new_args, **kwargs)  
+            kwargs = {"ctx": get_scheduler(name=opt)} if opt != "" else {}  
+            result_tensor = Tensor(jl.Finch.compute(result._obj, **kwargs))  
+            return result_tensor  
+        return wrapper_func  
 
-        return result_tensor
-
-    return wrapper_func
-
+    return inner  
 
 def lazy(tensor: Tensor):
     if tensor.is_computed():
@@ -34,16 +40,10 @@ def set_optimizer(opt="default"):
         jl.Finch.set_scheduler_b(jl.Finch.galley_scheduler())
     return
 
-def clear_optimizer_cache():
-    jl.empty_b(jl.Finch.codes)
-    return
-
-def compute(tensor: Tensor, *, verbose: bool = False, opt=""):
+def compute(tensor: Tensor, *, verbose: bool = False, opt="", tag=-1):
     if not tensor.is_computed():
         if opt == "":
-            return Tensor(jl.Finch.compute(tensor._obj, verbose=verbose))
-        elif opt == "default":
-            return Tensor(jl.Finch.compute(tensor._obj, verbose=verbose, ctx=jl.Finch.default_scheduler()))
-        elif opt == "galley":
-            return Tensor(jl.Finch.compute(tensor._obj, verbose=verbose, ctx=jl.Finch.galley_scheduler(verbose=verbose)))
+            return Tensor(jl.Finch.compute(tensor._obj, verbose=verbose, tag=tag))
+        else:            
+            return Tensor(jl.Finch.compute(tensor._obj, verbose=verbose, tag=tag, ctx=get_scheduler(opt, verbose=verbose)))
     return tensor

--- a/src/finch/compiled.py
+++ b/src/finch/compiled.py
@@ -15,7 +15,7 @@ def compiled(func, opt="galley"):
                 new_args.append(arg)
 
         result = func(*new_args, **kwargs)
-        result_tensor = Tensor(jl.Finch.compute(result._obj, opt=opt))
+        result_tensor = compute(result, opt=opt)
 
         return result_tensor
 

--- a/src/finch/compiled.py
+++ b/src/finch/compiled.py
@@ -34,18 +34,18 @@ class GalleyScheduler(AbstractScheduler):
     def __init__(self, verbose=False):
         self.verbose=verbose
 
+    def get_julia_scheduler(self):
+        return jl.Finch.galley_scheduler(verbose=self.verbose)
+    
 class DefaultScheduler(AbstractScheduler):
     def __init__(self, verbose=False):
         self.verbose=verbose
 
-def get_julia_scheduler(opt):
-    if isinstance(opt, DefaultScheduler):
-        return jl.Finch.default_scheduler(verbose=opt.verbose)
-    elif isinstance(opt, GalleyScheduler):
-        return jl.Finch.galley_scheduler(verbose=opt.verbose)
+    def get_julia_scheduler(self):
+        return jl.Finch.default_scheduler(verbose=self.verbose)
 
 def set_optimizer(opt):
-    jl.Finch.set_scheduler_b(get_julia_scheduler(opt))
+    jl.Finch.set_scheduler_b(opt.get_julia_scheduler())
     return
 
 def compute(tensor: Tensor, *, verbose: bool = False, opt=None, tag=-1):
@@ -53,5 +53,5 @@ def compute(tensor: Tensor, *, verbose: bool = False, opt=None, tag=-1):
         if opt == None:
             return Tensor(jl.Finch.compute(tensor._obj, verbose=verbose, tag=tag))
         else:            
-            return Tensor(jl.Finch.compute(tensor._obj, verbose=verbose, tag=tag, ctx=get_julia_scheduler(opt)))
+            return Tensor(jl.Finch.compute(tensor._obj, verbose=verbose, tag=tag, ctx=opt.get_julia_scheduler()))
     return tensor

--- a/src/finch/julia.py
+++ b/src/finch/julia.py
@@ -11,7 +11,7 @@ def add_package(name: str, hash: str, version: str) -> None:
 
 
 _FINCH_NAME = "Finch"
-_FINCH_VERSION = "0.6.32"
+_FINCH_VERSION = "0.6.33"
 _FINCH_HASH = "9177782c-1635-4eb9-9bfb-d9dfa25e6bce"
 _FINCH_REPO_PATH = os.environ.get("FINCH_REPO_PATH", default=None)
 _FINCH_REPO_URL = os.environ.get("FINCH_URL_PATH", default=None)

--- a/src/finch/julia.py
+++ b/src/finch/julia.py
@@ -11,7 +11,7 @@ def add_package(name: str, hash: str, version: str) -> None:
 
 
 _FINCH_NAME = "Finch"
-_FINCH_VERSION = "0.6.33"
+_FINCH_VERSION = "1.0"
 _FINCH_HASH = "9177782c-1635-4eb9-9bfb-d9dfa25e6bce"
 _FINCH_REPO_PATH = os.environ.get("FINCH_REPO_PATH", default=None)
 _FINCH_REPO_URL = os.environ.get("FINCH_URL_PATH", default=None)

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -9,7 +9,7 @@ arr2d = np.array([[1, 2, 0, 0], [0, 1, 0, 1]])
 
 arr1d = np.array([1, 1, 2, 3])
 
-parametrize_optimizer = pytest.mark.parametrize("opt", ["default", "galley"])  
+parametrize_optimizer = pytest.mark.parametrize("opt", [finch.DefaultScheduler(), finch.GalleyScheduler()])  
 
 @parametrize_optimizer
 def test_eager(arr3d, opt):

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -9,8 +9,9 @@ arr2d = np.array([[1, 2, 0, 0], [0, 1, 0, 1]])
 
 arr1d = np.array([1, 1, 2, 3])
 
-
-def test_eager(arr3d):
+@pytest.mark.parametrize("opt", ["default", "galley"])
+def test_eager(arr3d, opt):
+    finch.set_optimizer(opt)
     A_finch = finch.Tensor(arr3d)
     B_finch = finch.Tensor(arr2d)
 
@@ -19,7 +20,9 @@ def test_eager(arr3d):
     assert_equal(result.todense(), np.multiply(arr3d, arr2d))
 
 
-def test_lazy_mode(arr3d):
+@pytest.mark.parametrize("opt", ["default", "galley"])
+def test_lazy_mode(arr3d, opt):
+    finch.set_optimizer(opt)
     A_finch = finch.Tensor(arr3d)
     B_finch = finch.Tensor(arr2d)
     C_finch = finch.Tensor(arr1d)
@@ -66,7 +69,9 @@ def test_lazy_mode(arr3d):
         "trunc",
     ],
 )
-def test_elemwise_ops_1_arg(arr3d, func_name):
+@pytest.mark.parametrize("opt", ["default", "galley"])
+def test_elemwise_ops_1_arg(arr3d, func_name, opt):
+    finch.set_optimizer(opt)
     arr = arr3d + 1.6
     A_finch = finch.Tensor(arr)
 
@@ -80,7 +85,9 @@ def test_elemwise_ops_1_arg(arr3d, func_name):
     "func_name", ["real", "imag", "conj"]
 )
 @pytest.mark.parametrize("dtype", [np.complex128, np.complex64, np.float64, np.int64])
-def test_elemwise_complex_ops_1_arg(func_name, dtype):
+@pytest.mark.parametrize("opt", ["default", "galley"])
+def test_elemwise_complex_ops_1_arg(func_name, dtype, opt):
+    finch.set_optimizer(opt)
     arr = np.asarray([[1+1j, 2+2j], [3+3j, 4-4j], [-5-5j, -6-6j]]).astype(dtype)
     arr_finch = finch.asarray(arr)
 
@@ -95,7 +102,9 @@ def test_elemwise_complex_ops_1_arg(func_name, dtype):
     "meth_name",
     ["__pos__", "__neg__", "__abs__", "__invert__"],
 )
-def test_elemwise_tensor_ops_1_arg(arr3d, meth_name):
+@pytest.mark.parametrize("opt", ["default", "galley"])
+def test_elemwise_tensor_ops_1_arg(arr3d, meth_name, opt):
+    finch.set_optimizer(opt)
     A_finch = finch.Tensor(arr3d)
 
     actual = getattr(A_finch, meth_name)()
@@ -108,7 +117,9 @@ def test_elemwise_tensor_ops_1_arg(arr3d, meth_name):
     "func_name",
     ["logaddexp", "logical_and", "logical_or", "logical_xor"],
 )
-def test_elemwise_ops_2_args(arr3d, func_name):
+@pytest.mark.parametrize("opt", ["default", "galley"])
+def test_elemwise_ops_2_args(arr3d, func_name, opt):
+    finch.set_optimizer(opt)
     arr2d = np.array([[0, 3, 2, 0], [0, 0, 3, 2]])
     if func_name.startswith("logical"):
         arr3d = arr3d.astype(bool)
@@ -145,7 +156,9 @@ def test_elemwise_ops_2_args(arr3d, func_name):
         "__ne__",
     ],
 )
-def test_elemwise_tensor_ops_2_args(arr3d, meth_name):
+@pytest.mark.parametrize("opt", ["default", "galley"])
+def test_elemwise_tensor_ops_2_args(arr3d, meth_name, opt):
+    finch.set_optimizer(opt)
     arr2d = np.array([[2, 3, 2, 3], [3, 2, 3, 2]])
     A_finch = finch.Tensor(arr3d)
     B_finch = finch.Tensor(arr2d)
@@ -158,7 +171,9 @@ def test_elemwise_tensor_ops_2_args(arr3d, meth_name):
 
 @pytest.mark.parametrize("func_name", ["sum", "prod", "max", "min", "any", "all"])
 @pytest.mark.parametrize("axis", [None, -1, 1, (0, 1), (0, 1, 2)])
-def test_reductions(arr3d, func_name, axis):
+@pytest.mark.parametrize("opt", ["default", "galley"])
+def test_reductions(arr3d, func_name, axis, opt):
+    finch.set_optimizer(opt)
     A_finch = finch.Tensor(arr3d)
 
     actual = getattr(finch, func_name)(A_finch, axis=axis)
@@ -179,7 +194,9 @@ def test_reductions(arr3d, func_name, axis):
         (finch.float64, finch.complex128, np.complex128),
     ],
 )
-def test_sum_prod_dtype_arg(arr3d, func_name, axis, in_dtype, dtype, expected_dtype):
+@pytest.mark.parametrize("opt", ["default", "galley"])
+def test_sum_prod_dtype_arg(arr3d, func_name, axis, in_dtype, dtype, expected_dtype, opt):
+    finch.set_optimizer(opt)
     arr_finch = finch.asarray(np.abs(arr3d), dtype=in_dtype)
 
     actual = getattr(finch, func_name)(arr_finch, axis=axis, dtype=dtype).todense()
@@ -205,7 +222,9 @@ def test_sum_prod_dtype_arg(arr3d, func_name, axis, in_dtype, dtype, expected_dt
         ),
     ],
 )
-def test_tensordot(arr3d, storage):
+@pytest.mark.parametrize("opt", ["default", "galley"])
+def test_tensordot(arr3d, storage, opt):
+    finch.set_optimizer(opt)
     A_finch = finch.Tensor(arr1d)
     B_finch = finch.Tensor(arr2d)
     C_finch = finch.Tensor(arr3d)
@@ -233,7 +252,9 @@ def test_tensordot(arr3d, storage):
     assert_equal(actual.todense(), expected)
 
 
-def test_matmul(arr2d, arr3d):
+@pytest.mark.parametrize("opt", ["default", "galley"])
+def test_matmul(arr2d, arr3d, opt):
+    finch.set_optimizer(opt)
     A_finch = finch.Tensor(arr2d)
     B_finch = finch.Tensor(arr2d.T)
     C_finch = finch.permute_dims(A_finch, (1, 0))
@@ -250,7 +271,9 @@ def test_matmul(arr2d, arr3d):
         A_finch @ D_finch
 
 
-def test_negative__mod__():
+@pytest.mark.parametrize("opt", ["default", "galley"])
+def test_negative__mod__(opt):
+    finch.set_optimizer(opt)
     arr = np.array([-1, 0, 0, -2, -3, 0])
     arr_finch = finch.asarray(arr)
 

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -9,7 +9,9 @@ arr2d = np.array([[1, 2, 0, 0], [0, 1, 0, 1]])
 
 arr1d = np.array([1, 1, 2, 3])
 
-@pytest.mark.parametrize("opt", ["default", "galley"])
+parametrize_optimizer = pytest.mark.parametrize("opt", ["default", "galley"])  
+
+@parametrize_optimizer
 def test_eager(arr3d, opt):
     finch.set_optimizer(opt)
     finch.clear_optimizer_cache()
@@ -21,7 +23,7 @@ def test_eager(arr3d, opt):
     assert_equal(result.todense(), np.multiply(arr3d, arr2d))
 
 
-@pytest.mark.parametrize("opt", ["default", "galley"])
+@parametrize_optimizer
 def test_lazy_mode(arr3d, opt):
     finch.set_optimizer(opt)
     finch.clear_optimizer_cache()
@@ -71,7 +73,7 @@ def test_lazy_mode(arr3d, opt):
         "trunc",
     ],
 )
-@pytest.mark.parametrize("opt", ["default", "galley"])
+@parametrize_optimizer
 def test_elemwise_ops_1_arg(arr3d, func_name, opt):
     finch.set_optimizer(opt)
     finch.clear_optimizer_cache()
@@ -88,7 +90,7 @@ def test_elemwise_ops_1_arg(arr3d, func_name, opt):
     "func_name", ["real", "imag", "conj"]
 )
 @pytest.mark.parametrize("dtype", [np.complex128, np.complex64, np.float64, np.int64])
-@pytest.mark.parametrize("opt", ["default", "galley"])
+@parametrize_optimizer
 def test_elemwise_complex_ops_1_arg(func_name, dtype, opt):
     finch.set_optimizer(opt)
     finch.clear_optimizer_cache()
@@ -106,7 +108,7 @@ def test_elemwise_complex_ops_1_arg(func_name, dtype, opt):
     "meth_name",
     ["__pos__", "__neg__", "__abs__", "__invert__"],
 )
-@pytest.mark.parametrize("opt", ["default", "galley"])
+@parametrize_optimizer
 def test_elemwise_tensor_ops_1_arg(arr3d, meth_name, opt):
     finch.set_optimizer(opt)
     finch.clear_optimizer_cache()
@@ -122,7 +124,7 @@ def test_elemwise_tensor_ops_1_arg(arr3d, meth_name, opt):
     "func_name",
     ["logaddexp", "logical_and", "logical_or", "logical_xor"],
 )
-@pytest.mark.parametrize("opt", ["default", "galley"])
+@parametrize_optimizer
 def test_elemwise_ops_2_args(arr3d, func_name, opt):
     finch.set_optimizer(opt)
     finch.clear_optimizer_cache()
@@ -162,7 +164,7 @@ def test_elemwise_ops_2_args(arr3d, func_name, opt):
         "__ne__",
     ],
 )
-@pytest.mark.parametrize("opt", ["default", "galley"])
+@parametrize_optimizer
 def test_elemwise_tensor_ops_2_args(arr3d, meth_name, opt):
     finch.set_optimizer(opt)
     finch.clear_optimizer_cache()
@@ -178,7 +180,7 @@ def test_elemwise_tensor_ops_2_args(arr3d, meth_name, opt):
 
 @pytest.mark.parametrize("func_name", ["sum", "prod", "max", "min", "any", "all"])
 @pytest.mark.parametrize("axis", [None, -1, 1, (0, 1), (0, 1, 2)])
-@pytest.mark.parametrize("opt", ["default", "galley"])
+@parametrize_optimizer
 def test_reductions(arr3d, func_name, axis, opt):
     finch.set_optimizer(opt)
     finch.clear_optimizer_cache()
@@ -202,7 +204,7 @@ def test_reductions(arr3d, func_name, axis, opt):
         (finch.float64, finch.complex128, np.complex128),
     ],
 )
-@pytest.mark.parametrize("opt", ["default", "galley"])
+@parametrize_optimizer
 def test_sum_prod_dtype_arg(arr3d, func_name, axis, in_dtype, dtype, expected_dtype, opt):
     finch.set_optimizer(opt)
     finch.clear_optimizer_cache()
@@ -231,7 +233,7 @@ def test_sum_prod_dtype_arg(arr3d, func_name, axis, in_dtype, dtype, expected_dt
         ),
     ],
 )
-@pytest.mark.parametrize("opt", ["default", "galley"])
+@parametrize_optimizer
 def test_tensordot(arr3d, storage, opt):
     finch.set_optimizer(opt)
     finch.clear_optimizer_cache()
@@ -262,7 +264,7 @@ def test_tensordot(arr3d, storage, opt):
     assert_equal(actual.todense(), expected)
 
 
-@pytest.mark.parametrize("opt", ["default", "galley"])
+@parametrize_optimizer
 def test_matmul(arr2d, arr3d, opt):
     finch.set_optimizer(opt)
     finch.clear_optimizer_cache()
@@ -282,7 +284,7 @@ def test_matmul(arr2d, arr3d, opt):
         A_finch @ D_finch
 
 
-@pytest.mark.parametrize("opt", ["default", "galley"])
+@parametrize_optimizer
 def test_negative__mod__(opt):
     finch.set_optimizer(opt)
     finch.clear_optimizer_cache()

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -14,7 +14,7 @@ parametrize_optimizer = pytest.mark.parametrize("opt", ["default", "galley"])
 @parametrize_optimizer
 def test_eager(arr3d, opt):
     finch.set_optimizer(opt)
-    finch.clear_optimizer_cache()
+    
     A_finch = finch.Tensor(arr3d)
     B_finch = finch.Tensor(arr2d)
 
@@ -26,12 +26,12 @@ def test_eager(arr3d, opt):
 @parametrize_optimizer
 def test_lazy_mode(arr3d, opt):
     finch.set_optimizer(opt)
-    finch.clear_optimizer_cache()
+    
     A_finch = finch.Tensor(arr3d)
     B_finch = finch.Tensor(arr2d)
     C_finch = finch.Tensor(arr1d)
 
-    @finch.compiled
+    @finch.compiled()
     def my_custom_fun(arr1, arr2, arr3):
         temp = finch.multiply(arr1, arr2)
         temp = finch.divide(temp, arr3)
@@ -76,7 +76,7 @@ def test_lazy_mode(arr3d, opt):
 @parametrize_optimizer
 def test_elemwise_ops_1_arg(arr3d, func_name, opt):
     finch.set_optimizer(opt)
-    finch.clear_optimizer_cache()
+    
     arr = arr3d + 1.6
     A_finch = finch.Tensor(arr)
 
@@ -93,7 +93,7 @@ def test_elemwise_ops_1_arg(arr3d, func_name, opt):
 @parametrize_optimizer
 def test_elemwise_complex_ops_1_arg(func_name, dtype, opt):
     finch.set_optimizer(opt)
-    finch.clear_optimizer_cache()
+    
     arr = np.asarray([[1+1j, 2+2j], [3+3j, 4-4j], [-5-5j, -6-6j]]).astype(dtype)
     arr_finch = finch.asarray(arr)
 
@@ -111,7 +111,7 @@ def test_elemwise_complex_ops_1_arg(func_name, dtype, opt):
 @parametrize_optimizer
 def test_elemwise_tensor_ops_1_arg(arr3d, meth_name, opt):
     finch.set_optimizer(opt)
-    finch.clear_optimizer_cache()
+    
     A_finch = finch.Tensor(arr3d)
 
     actual = getattr(A_finch, meth_name)()
@@ -127,7 +127,7 @@ def test_elemwise_tensor_ops_1_arg(arr3d, meth_name, opt):
 @parametrize_optimizer
 def test_elemwise_ops_2_args(arr3d, func_name, opt):
     finch.set_optimizer(opt)
-    finch.clear_optimizer_cache()
+    
     arr2d = np.array([[0, 3, 2, 0], [0, 0, 3, 2]])
     if func_name.startswith("logical"):
         arr3d = arr3d.astype(bool)
@@ -167,7 +167,7 @@ def test_elemwise_ops_2_args(arr3d, func_name, opt):
 @parametrize_optimizer
 def test_elemwise_tensor_ops_2_args(arr3d, meth_name, opt):
     finch.set_optimizer(opt)
-    finch.clear_optimizer_cache()
+    
     arr2d = np.array([[2, 3, 2, 3], [3, 2, 3, 2]])
     A_finch = finch.Tensor(arr3d)
     B_finch = finch.Tensor(arr2d)
@@ -183,7 +183,7 @@ def test_elemwise_tensor_ops_2_args(arr3d, meth_name, opt):
 @parametrize_optimizer
 def test_reductions(arr3d, func_name, axis, opt):
     finch.set_optimizer(opt)
-    finch.clear_optimizer_cache()
+    
     A_finch = finch.Tensor(arr3d)
 
     actual = getattr(finch, func_name)(A_finch, axis=axis)
@@ -207,7 +207,7 @@ def test_reductions(arr3d, func_name, axis, opt):
 @parametrize_optimizer
 def test_sum_prod_dtype_arg(arr3d, func_name, axis, in_dtype, dtype, expected_dtype, opt):
     finch.set_optimizer(opt)
-    finch.clear_optimizer_cache()
+    
     arr_finch = finch.asarray(np.abs(arr3d), dtype=in_dtype)
 
     actual = getattr(finch, func_name)(arr_finch, axis=axis, dtype=dtype).todense()
@@ -236,7 +236,7 @@ def test_sum_prod_dtype_arg(arr3d, func_name, axis, in_dtype, dtype, expected_dt
 @parametrize_optimizer
 def test_tensordot(arr3d, storage, opt):
     finch.set_optimizer(opt)
-    finch.clear_optimizer_cache()
+    
     A_finch = finch.Tensor(arr1d)
     B_finch = finch.Tensor(arr2d)
     C_finch = finch.Tensor(arr3d)
@@ -267,7 +267,7 @@ def test_tensordot(arr3d, storage, opt):
 @parametrize_optimizer
 def test_matmul(arr2d, arr3d, opt):
     finch.set_optimizer(opt)
-    finch.clear_optimizer_cache()
+    
     A_finch = finch.Tensor(arr2d)
     B_finch = finch.Tensor(arr2d.T)
     C_finch = finch.permute_dims(A_finch, (1, 0))
@@ -287,7 +287,7 @@ def test_matmul(arr2d, arr3d, opt):
 @parametrize_optimizer
 def test_negative__mod__(opt):
     finch.set_optimizer(opt)
-    finch.clear_optimizer_cache()
+    
     arr = np.array([-1, 0, 0, -2, -3, 0])
     arr_finch = finch.asarray(arr)
 

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -12,6 +12,7 @@ arr1d = np.array([1, 1, 2, 3])
 @pytest.mark.parametrize("opt", ["default", "galley"])
 def test_eager(arr3d, opt):
     finch.set_optimizer(opt)
+    finch.clear_optimizer_cache()
     A_finch = finch.Tensor(arr3d)
     B_finch = finch.Tensor(arr2d)
 
@@ -23,6 +24,7 @@ def test_eager(arr3d, opt):
 @pytest.mark.parametrize("opt", ["default", "galley"])
 def test_lazy_mode(arr3d, opt):
     finch.set_optimizer(opt)
+    finch.clear_optimizer_cache()
     A_finch = finch.Tensor(arr3d)
     B_finch = finch.Tensor(arr2d)
     C_finch = finch.Tensor(arr1d)
@@ -72,6 +74,7 @@ def test_lazy_mode(arr3d, opt):
 @pytest.mark.parametrize("opt", ["default", "galley"])
 def test_elemwise_ops_1_arg(arr3d, func_name, opt):
     finch.set_optimizer(opt)
+    finch.clear_optimizer_cache()
     arr = arr3d + 1.6
     A_finch = finch.Tensor(arr)
 
@@ -88,6 +91,7 @@ def test_elemwise_ops_1_arg(arr3d, func_name, opt):
 @pytest.mark.parametrize("opt", ["default", "galley"])
 def test_elemwise_complex_ops_1_arg(func_name, dtype, opt):
     finch.set_optimizer(opt)
+    finch.clear_optimizer_cache()
     arr = np.asarray([[1+1j, 2+2j], [3+3j, 4-4j], [-5-5j, -6-6j]]).astype(dtype)
     arr_finch = finch.asarray(arr)
 
@@ -105,6 +109,7 @@ def test_elemwise_complex_ops_1_arg(func_name, dtype, opt):
 @pytest.mark.parametrize("opt", ["default", "galley"])
 def test_elemwise_tensor_ops_1_arg(arr3d, meth_name, opt):
     finch.set_optimizer(opt)
+    finch.clear_optimizer_cache()
     A_finch = finch.Tensor(arr3d)
 
     actual = getattr(A_finch, meth_name)()
@@ -120,6 +125,7 @@ def test_elemwise_tensor_ops_1_arg(arr3d, meth_name, opt):
 @pytest.mark.parametrize("opt", ["default", "galley"])
 def test_elemwise_ops_2_args(arr3d, func_name, opt):
     finch.set_optimizer(opt)
+    finch.clear_optimizer_cache()
     arr2d = np.array([[0, 3, 2, 0], [0, 0, 3, 2]])
     if func_name.startswith("logical"):
         arr3d = arr3d.astype(bool)
@@ -159,6 +165,7 @@ def test_elemwise_ops_2_args(arr3d, func_name, opt):
 @pytest.mark.parametrize("opt", ["default", "galley"])
 def test_elemwise_tensor_ops_2_args(arr3d, meth_name, opt):
     finch.set_optimizer(opt)
+    finch.clear_optimizer_cache()
     arr2d = np.array([[2, 3, 2, 3], [3, 2, 3, 2]])
     A_finch = finch.Tensor(arr3d)
     B_finch = finch.Tensor(arr2d)
@@ -174,6 +181,7 @@ def test_elemwise_tensor_ops_2_args(arr3d, meth_name, opt):
 @pytest.mark.parametrize("opt", ["default", "galley"])
 def test_reductions(arr3d, func_name, axis, opt):
     finch.set_optimizer(opt)
+    finch.clear_optimizer_cache()
     A_finch = finch.Tensor(arr3d)
 
     actual = getattr(finch, func_name)(A_finch, axis=axis)
@@ -197,6 +205,7 @@ def test_reductions(arr3d, func_name, axis, opt):
 @pytest.mark.parametrize("opt", ["default", "galley"])
 def test_sum_prod_dtype_arg(arr3d, func_name, axis, in_dtype, dtype, expected_dtype, opt):
     finch.set_optimizer(opt)
+    finch.clear_optimizer_cache()
     arr_finch = finch.asarray(np.abs(arr3d), dtype=in_dtype)
 
     actual = getattr(finch, func_name)(arr_finch, axis=axis, dtype=dtype).todense()
@@ -225,6 +234,7 @@ def test_sum_prod_dtype_arg(arr3d, func_name, axis, in_dtype, dtype, expected_dt
 @pytest.mark.parametrize("opt", ["default", "galley"])
 def test_tensordot(arr3d, storage, opt):
     finch.set_optimizer(opt)
+    finch.clear_optimizer_cache()
     A_finch = finch.Tensor(arr1d)
     B_finch = finch.Tensor(arr2d)
     C_finch = finch.Tensor(arr3d)
@@ -255,6 +265,7 @@ def test_tensordot(arr3d, storage, opt):
 @pytest.mark.parametrize("opt", ["default", "galley"])
 def test_matmul(arr2d, arr3d, opt):
     finch.set_optimizer(opt)
+    finch.clear_optimizer_cache()
     A_finch = finch.Tensor(arr2d)
     B_finch = finch.Tensor(arr2d.T)
     C_finch = finch.permute_dims(A_finch, (1, 0))
@@ -274,6 +285,7 @@ def test_matmul(arr2d, arr3d, opt):
 @pytest.mark.parametrize("opt", ["default", "galley"])
 def test_negative__mod__(opt):
     finch.set_optimizer(opt)
+    finch.clear_optimizer_cache()
     arr = np.array([-1, 0, 0, -2, -3, 0])
     arr_finch = finch.asarray(arr)
 

--- a/tests/test_sparse.py
+++ b/tests/test_sparse.py
@@ -118,6 +118,7 @@ def test_csf(arr3d):
 @pytest.mark.parametrize("order", ["C", "F"])
 @pytest.mark.parametrize("opt", ["default", "galley"])
 def test_permute_dims(arr3d, permutation, order, opt):
+    finch.clear_optimizer_cache()
     finch.set_optimizer(opt)
     arr = np.array(arr3d, order=order)
     storage = finch.Storage(
@@ -148,6 +149,7 @@ def test_permute_dims(arr3d, permutation, order, opt):
 @pytest.mark.parametrize("order", ["C", "F"])
 @pytest.mark.parametrize("opt", ["default", "galley"])
 def test_astype(arr3d, order, opt):
+    finch.clear_optimizer_cache()
     finch.set_optimizer(opt)
     arr = np.array(arr3d, order=order, dtype=np.int64)
     storage = finch.Storage(
@@ -182,6 +184,7 @@ def test_astype(arr3d, order, opt):
 @pytest.mark.parametrize("random_state", [42, np.random.default_rng(42)])
 @pytest.mark.parametrize("opt", ["default", "galley"])
 def test_random(random_state, opt):
+    finch.clear_optimizer_cache()
     finch.set_optimizer(opt)
     result = finch.random((10, 20, 30), density=0.0, random_state=random_state)
     expected = sparse.random((10, 20, 30), density=0.0, random_state=random_state)
@@ -223,6 +226,7 @@ def test_asarray(arr2d, arr3d, order, format, opt):
 @pytest.mark.parametrize("opt", ["default", "galley"])
 def test_reshape(arr, new_shape, order, opt):
     finch.set_optimizer(opt)
+    finch.clear_optimizer_cache()
     arr = np.array(arr, order=order)
     arr_finch = finch.Tensor(arr)
 
@@ -236,6 +240,7 @@ def test_reshape(arr, new_shape, order, opt):
 @pytest.mark.parametrize("opt", ["default", "galley"])
 def test_full_ones_zeros_empty(shape, dtype_name, format, opt):
     finch.set_optimizer(opt)
+    finch.clear_optimizer_cache()
     jl_dtype = getattr(finch, dtype_name) if dtype_name is not None else None
     np_dtype = getattr(np, dtype_name) if dtype_name is not None else None
 
@@ -277,6 +282,7 @@ def test_device_keyword(func, arg):
 @pytest.mark.parametrize("opt", ["default", "galley"])
 def test_where(order_and_format, opt):
     finch.set_optimizer(opt)
+    finch.clear_optimizer_cache()
     order, format = order_and_format
     cond = np.array(
         [
@@ -313,6 +319,7 @@ def test_where(order_and_format, opt):
 @pytest.mark.parametrize("opt", ["default", "galley"])
 def test_nonzero(order, format_shape, opt):
     finch.set_optimizer(opt)
+    finch.clear_optimizer_cache()
     format, shape = format_shape
     rng = np.random.default_rng(0)
     arr = rng.random(shape)
@@ -334,6 +341,7 @@ def test_nonzero(order, format_shape, opt):
 @pytest.mark.parametrize("opt", ["default", "galley"])
 def test_eye(dtype_name, k, format, opt):
     finch.set_optimizer(opt)
+    finch.clear_optimizer_cache()
     result = finch.eye(3, 4, k=k, dtype=getattr(finch, dtype_name), format=format)
     expected = np.eye(3, 4, k=k, dtype=getattr(np, dtype_name))
 
@@ -343,6 +351,7 @@ def test_eye(dtype_name, k, format, opt):
 @pytest.mark.parametrize("opt", ["default", "galley"])
 def test_to_scalar(opt):
     finch.set_optimizer(opt)
+    finch.clear_optimizer_cache()
     for obj, meth_name in [
         (True, "__bool__"), (1, "__int__"), (1.0, "__float__"), (1, "__index__"), (1+1j, "__complex__")
     ]:
@@ -360,6 +369,7 @@ def test_to_scalar(opt):
 @pytest.mark.parametrize("opt", ["default", "galley"])
 def test_arange_linspace(dtype_name, opt):
     finch.set_optimizer(opt)
+    finch.clear_optimizer_cache()
     if dtype_name is not None:
         finch_dtype = getattr(finch, dtype_name)
         np_dtype = getattr(np, dtype_name)

--- a/tests/test_sparse.py
+++ b/tests/test_sparse.py
@@ -116,7 +116,9 @@ def test_csf(arr3d):
     "permutation", [(0, 1, 2), (2, 1, 0), (0, 2, 1), (1, 2, 0), (2, 0, 1)]
 )
 @pytest.mark.parametrize("order", ["C", "F"])
-def test_permute_dims(arr3d, permutation, order):
+@pytest.mark.parametrize("opt", ["default", "galley"])
+def test_permute_dims(arr3d, permutation, order, opt):
+    finch.set_optimizer(opt)
     arr = np.array(arr3d, order=order)
     storage = finch.Storage(
         finch.Dense(finch.SparseList(finch.SparseList(finch.Element(0)))), order=order
@@ -144,7 +146,9 @@ def test_permute_dims(arr3d, permutation, order):
 
 
 @pytest.mark.parametrize("order", ["C", "F"])
-def test_astype(arr3d, order):
+@pytest.mark.parametrize("opt", ["default", "galley"])
+def test_astype(arr3d, order, opt):
+    finch.set_optimizer(opt)
     arr = np.array(arr3d, order=order, dtype=np.int64)
     storage = finch.Storage(
         finch.Dense(finch.SparseList(finch.SparseList(finch.Element(np.int64(0))))),
@@ -176,7 +180,9 @@ def test_astype(arr3d, order):
 
 
 @pytest.mark.parametrize("random_state", [42, np.random.default_rng(42)])
-def test_random(random_state):
+@pytest.mark.parametrize("opt", ["default", "galley"])
+def test_random(random_state, opt):
+    finch.set_optimizer(opt)
     result = finch.random((10, 20, 30), density=0.0, random_state=random_state)
     expected = sparse.random((10, 20, 30), density=0.0, random_state=random_state)
 
@@ -192,7 +198,9 @@ def test_random(random_state):
 
 @pytest.mark.parametrize("order", ["C", "F"])
 @pytest.mark.parametrize("format", ["coo", "csr", "csc", "csf", "dense", None])
-def test_asarray(arr2d, arr3d, order, format):
+@pytest.mark.parametrize("opt", ["default", "galley"])
+def test_asarray(arr2d, arr3d, order, format, opt):
+    finch.set_optimizer(opt)
     arr = arr3d if format == "csf" else arr2d
     arr = np.array(arr, order=order)
     arr_finch = finch.Tensor(arr)
@@ -212,7 +220,9 @@ def test_asarray(arr2d, arr3d, order, format):
     ],
 )
 @pytest.mark.parametrize("order", ["C", "F"])
-def test_reshape(arr, new_shape, order):
+@pytest.mark.parametrize("opt", ["default", "galley"])
+def test_reshape(arr, new_shape, order, opt):
+    finch.set_optimizer(opt)
     arr = np.array(arr, order=order)
     arr_finch = finch.Tensor(arr)
 
@@ -223,7 +233,9 @@ def test_reshape(arr, new_shape, order):
 @pytest.mark.parametrize("shape", [10, (3, 3), (2, 1, 5)])
 @pytest.mark.parametrize("dtype_name", [None, "int64", "float64"])
 @pytest.mark.parametrize("format", ["coo", "dense"])
-def test_full_ones_zeros_empty(shape, dtype_name, format):
+@pytest.mark.parametrize("opt", ["default", "galley"])
+def test_full_ones_zeros_empty(shape, dtype_name, format, opt):
+    finch.set_optimizer(opt)
     jl_dtype = getattr(finch, dtype_name) if dtype_name is not None else None
     np_dtype = getattr(np, dtype_name) if dtype_name is not None else None
 
@@ -262,7 +274,9 @@ def test_device_keyword(func, arg):
     "order_and_format",
     [("C", None), ("F", None), ("C", "coo"), ("F", "coo"), ("F", "csc")],
 )
-def test_where(order_and_format):
+@pytest.mark.parametrize("opt", ["default", "galley"])
+def test_where(order_and_format, opt):
+    finch.set_optimizer(opt)
     order, format = order_and_format
     cond = np.array(
         [
@@ -296,7 +310,9 @@ def test_where(order_and_format):
         ("csc", (5, 10)),
     ],
 )
-def test_nonzero(order, format_shape):
+@pytest.mark.parametrize("opt", ["default", "galley"])
+def test_nonzero(order, format_shape, opt):
+    finch.set_optimizer(opt)
     format, shape = format_shape
     rng = np.random.default_rng(0)
     arr = rng.random(shape)
@@ -315,14 +331,18 @@ def test_nonzero(order, format_shape):
 @pytest.mark.parametrize("dtype_name", ["int64", "float64", "complex128"])
 @pytest.mark.parametrize("k", [0, -1, 1, -2, 2])
 @pytest.mark.parametrize("format", ["coo", "dense"])
-def test_eye(dtype_name, k, format):
+@pytest.mark.parametrize("opt", ["default", "galley"])
+def test_eye(dtype_name, k, format, opt):
+    finch.set_optimizer(opt)
     result = finch.eye(3, 4, k=k, dtype=getattr(finch, dtype_name), format=format)
     expected = np.eye(3, 4, k=k, dtype=getattr(np, dtype_name))
 
     assert_equal(result.todense(), expected)
 
 
-def test_to_scalar():
+@pytest.mark.parametrize("opt", ["default", "galley"])
+def test_to_scalar(opt):
+    finch.set_optimizer(opt)
     for obj, meth_name in [
         (True, "__bool__"), (1, "__int__"), (1.0, "__float__"), (1, "__index__"), (1+1j, "__complex__")
     ]:
@@ -337,7 +357,9 @@ def test_to_scalar():
 
 
 @pytest.mark.parametrize("dtype_name", [None, "int16", "float64"])
-def test_arange_linspace(dtype_name):
+@pytest.mark.parametrize("opt", ["default", "galley"])
+def test_arange_linspace(dtype_name, opt):
+    finch.set_optimizer(opt)
     if dtype_name is not None:
         finch_dtype = getattr(finch, dtype_name)
         np_dtype = getattr(np, dtype_name)

--- a/tests/test_sparse.py
+++ b/tests/test_sparse.py
@@ -119,7 +119,7 @@ def test_csf(arr3d):
 @pytest.mark.parametrize("order", ["C", "F"])
 @parametrize_optimizer
 def test_permute_dims(arr3d, permutation, order, opt):
-    finch.clear_optimizer_cache()
+    
     finch.set_optimizer(opt)
     arr = np.array(arr3d, order=order)
     storage = finch.Storage(
@@ -150,7 +150,7 @@ def test_permute_dims(arr3d, permutation, order, opt):
 @pytest.mark.parametrize("order", ["C", "F"])
 @parametrize_optimizer
 def test_astype(arr3d, order, opt):
-    finch.clear_optimizer_cache()
+    
     finch.set_optimizer(opt)
     arr = np.array(arr3d, order=order, dtype=np.int64)
     storage = finch.Storage(
@@ -185,7 +185,7 @@ def test_astype(arr3d, order, opt):
 @pytest.mark.parametrize("random_state", [42, np.random.default_rng(42)])
 @parametrize_optimizer
 def test_random(random_state, opt):
-    finch.clear_optimizer_cache()
+    
     finch.set_optimizer(opt)
     result = finch.random((10, 20, 30), density=0.0, random_state=random_state)
     expected = sparse.random((10, 20, 30), density=0.0, random_state=random_state)
@@ -227,7 +227,7 @@ def test_asarray(arr2d, arr3d, order, format, opt):
 @parametrize_optimizer
 def test_reshape(arr, new_shape, order, opt):
     finch.set_optimizer(opt)
-    finch.clear_optimizer_cache()
+    
     arr = np.array(arr, order=order)
     arr_finch = finch.Tensor(arr)
 
@@ -241,7 +241,7 @@ def test_reshape(arr, new_shape, order, opt):
 @parametrize_optimizer
 def test_full_ones_zeros_empty(shape, dtype_name, format, opt):
     finch.set_optimizer(opt)
-    finch.clear_optimizer_cache()
+    
     jl_dtype = getattr(finch, dtype_name) if dtype_name is not None else None
     np_dtype = getattr(np, dtype_name) if dtype_name is not None else None
 
@@ -283,7 +283,7 @@ def test_device_keyword(func, arg):
 @parametrize_optimizer
 def test_where(order_and_format, opt):
     finch.set_optimizer(opt)
-    finch.clear_optimizer_cache()
+    
     order, format = order_and_format
     cond = np.array(
         [
@@ -320,7 +320,7 @@ def test_where(order_and_format, opt):
 @parametrize_optimizer
 def test_nonzero(order, format_shape, opt):
     finch.set_optimizer(opt)
-    finch.clear_optimizer_cache()
+    
     format, shape = format_shape
     rng = np.random.default_rng(0)
     arr = rng.random(shape)
@@ -342,7 +342,7 @@ def test_nonzero(order, format_shape, opt):
 @parametrize_optimizer
 def test_eye(dtype_name, k, format, opt):
     finch.set_optimizer(opt)
-    finch.clear_optimizer_cache()
+    
     result = finch.eye(3, 4, k=k, dtype=getattr(finch, dtype_name), format=format)
     expected = np.eye(3, 4, k=k, dtype=getattr(np, dtype_name))
 
@@ -352,7 +352,7 @@ def test_eye(dtype_name, k, format, opt):
 @parametrize_optimizer
 def test_to_scalar(opt):
     finch.set_optimizer(opt)
-    finch.clear_optimizer_cache()
+    
     for obj, meth_name in [
         (True, "__bool__"), (1, "__int__"), (1.0, "__float__"), (1, "__index__"), (1+1j, "__complex__")
     ]:
@@ -370,7 +370,7 @@ def test_to_scalar(opt):
 @parametrize_optimizer
 def test_arange_linspace(dtype_name, opt):
     finch.set_optimizer(opt)
-    finch.clear_optimizer_cache()
+    
     if dtype_name is not None:
         finch_dtype = getattr(finch, dtype_name)
         np_dtype = getattr(np, dtype_name)

--- a/tests/test_sparse.py
+++ b/tests/test_sparse.py
@@ -5,7 +5,7 @@ import sparse
 
 import finch
 
-parametrize_optimizer =  pytest.mark.parametrize("opt", ["default", "galley"])
+parametrize_optimizer = pytest.mark.parametrize("opt", [finch.DefaultScheduler(), finch.GalleyScheduler()])  
 
 @pytest.mark.parametrize(
     "dtype,jl_dtype",

--- a/tests/test_sparse.py
+++ b/tests/test_sparse.py
@@ -5,6 +5,7 @@ import sparse
 
 import finch
 
+parametrize_optimizer =  pytest.mark.parametrize("opt", ["default", "galley"])
 
 @pytest.mark.parametrize(
     "dtype,jl_dtype",
@@ -116,7 +117,7 @@ def test_csf(arr3d):
     "permutation", [(0, 1, 2), (2, 1, 0), (0, 2, 1), (1, 2, 0), (2, 0, 1)]
 )
 @pytest.mark.parametrize("order", ["C", "F"])
-@pytest.mark.parametrize("opt", ["default", "galley"])
+@parametrize_optimizer
 def test_permute_dims(arr3d, permutation, order, opt):
     finch.clear_optimizer_cache()
     finch.set_optimizer(opt)
@@ -147,7 +148,7 @@ def test_permute_dims(arr3d, permutation, order, opt):
 
 
 @pytest.mark.parametrize("order", ["C", "F"])
-@pytest.mark.parametrize("opt", ["default", "galley"])
+@parametrize_optimizer
 def test_astype(arr3d, order, opt):
     finch.clear_optimizer_cache()
     finch.set_optimizer(opt)
@@ -182,7 +183,7 @@ def test_astype(arr3d, order, opt):
 
 
 @pytest.mark.parametrize("random_state", [42, np.random.default_rng(42)])
-@pytest.mark.parametrize("opt", ["default", "galley"])
+@parametrize_optimizer
 def test_random(random_state, opt):
     finch.clear_optimizer_cache()
     finch.set_optimizer(opt)
@@ -201,7 +202,7 @@ def test_random(random_state, opt):
 
 @pytest.mark.parametrize("order", ["C", "F"])
 @pytest.mark.parametrize("format", ["coo", "csr", "csc", "csf", "dense", None])
-@pytest.mark.parametrize("opt", ["default", "galley"])
+@parametrize_optimizer
 def test_asarray(arr2d, arr3d, order, format, opt):
     finch.set_optimizer(opt)
     arr = arr3d if format == "csf" else arr2d
@@ -223,7 +224,7 @@ def test_asarray(arr2d, arr3d, order, format, opt):
     ],
 )
 @pytest.mark.parametrize("order", ["C", "F"])
-@pytest.mark.parametrize("opt", ["default", "galley"])
+@parametrize_optimizer
 def test_reshape(arr, new_shape, order, opt):
     finch.set_optimizer(opt)
     finch.clear_optimizer_cache()
@@ -237,7 +238,7 @@ def test_reshape(arr, new_shape, order, opt):
 @pytest.mark.parametrize("shape", [10, (3, 3), (2, 1, 5)])
 @pytest.mark.parametrize("dtype_name", [None, "int64", "float64"])
 @pytest.mark.parametrize("format", ["coo", "dense"])
-@pytest.mark.parametrize("opt", ["default", "galley"])
+@parametrize_optimizer
 def test_full_ones_zeros_empty(shape, dtype_name, format, opt):
     finch.set_optimizer(opt)
     finch.clear_optimizer_cache()
@@ -279,7 +280,7 @@ def test_device_keyword(func, arg):
     "order_and_format",
     [("C", None), ("F", None), ("C", "coo"), ("F", "coo"), ("F", "csc")],
 )
-@pytest.mark.parametrize("opt", ["default", "galley"])
+@parametrize_optimizer
 def test_where(order_and_format, opt):
     finch.set_optimizer(opt)
     finch.clear_optimizer_cache()
@@ -316,7 +317,7 @@ def test_where(order_and_format, opt):
         ("csc", (5, 10)),
     ],
 )
-@pytest.mark.parametrize("opt", ["default", "galley"])
+@parametrize_optimizer
 def test_nonzero(order, format_shape, opt):
     finch.set_optimizer(opt)
     finch.clear_optimizer_cache()
@@ -338,7 +339,7 @@ def test_nonzero(order, format_shape, opt):
 @pytest.mark.parametrize("dtype_name", ["int64", "float64", "complex128"])
 @pytest.mark.parametrize("k", [0, -1, 1, -2, 2])
 @pytest.mark.parametrize("format", ["coo", "dense"])
-@pytest.mark.parametrize("opt", ["default", "galley"])
+@parametrize_optimizer
 def test_eye(dtype_name, k, format, opt):
     finch.set_optimizer(opt)
     finch.clear_optimizer_cache()
@@ -348,7 +349,7 @@ def test_eye(dtype_name, k, format, opt):
     assert_equal(result.todense(), expected)
 
 
-@pytest.mark.parametrize("opt", ["default", "galley"])
+@parametrize_optimizer
 def test_to_scalar(opt):
     finch.set_optimizer(opt)
     finch.clear_optimizer_cache()
@@ -366,7 +367,7 @@ def test_to_scalar(opt):
 
 
 @pytest.mark.parametrize("dtype_name", [None, "int16", "float64"])
-@pytest.mark.parametrize("opt", ["default", "galley"])
+@parametrize_optimizer
 def test_arange_linspace(dtype_name, opt):
     finch.set_optimizer(opt)
     finch.clear_optimizer_cache()


### PR DESCRIPTION
This PR enables galley optimization through the python interface in two ways 1) as a parameter to compute 2) by setting the global scheduler with set_optimizer.