### PR TITLE
fix julia package versioning, bump finch/juliapkg

### DIFF
--- a/juliapkg.json
+++ b/juliapkg.json
@@ -1,1 +1,21 @@
-{"packages": {"Finch": {"uuid": "9177782c-1635-4eb9-9bfb-d9dfa25e6bce", "version": "1.2.1"}}, "julia": "^1.10"}
+{
+    "packages": {
+        "Finch": {
+            "uuid": "9177782c-1635-4eb9-9bfb-d9dfa25e6bce",
+            "version": "1.2.1"
+        },
+        "HDF5": {
+            "uuid": "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f",
+            "version": "0.17.2"
+        },
+        "NPZ": {
+            "uuid": "15e1cf62-19b3-5cfa-8e77-841668bca605",
+            "version": "0.4.3"
+        },
+        "TensorMarket": {
+            "uuid": "8b7d4fe7-0b45-4d0d-9dd8-5cc9b23b4b77",
+            "version":"0.2.0"
+        }
+    },
+    "julia": "^1.10"
+}

--- a/juliapkg.json
+++ b/juliapkg.json
@@ -1,0 +1,1 @@
+{"packages": {"Finch": {"uuid": "9177782c-1635-4eb9-9bfb-d9dfa25e6bce", "version": "1.2.1"}}, "julia": "^1.10"}

--- a/juliapkg_dev.json
+++ b/juliapkg_dev.json
@@ -1,0 +1,1 @@
+{"packages": {"Finch": {"uuid": "9177782c-1635-4eb9-9bfb-d9dfa25e6bce", "dev": true, "path": "../Finch.jl"}}, "julia": "^1.10"}

--- a/juliapkg_dev.json
+++ b/juliapkg_dev.json
@@ -1,1 +1,22 @@
-{"packages": {"Finch": {"uuid": "9177782c-1635-4eb9-9bfb-d9dfa25e6bce", "dev": true, "path": "../Finch.jl"}}, "julia": "^1.10"}
+{
+    "packages": {
+        "Finch": {
+            "uuid": "9177782c-1635-4eb9-9bfb-d9dfa25e6bce",
+            "dev": true,
+            "path": "../Finch.jl"
+        },
+        "HDF5": {
+            "uuid": "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f",
+            "version": "0.17.2"
+        },
+        "NPZ": {
+            "uuid": "15e1cf62-19b3-5cfa-8e77-841668bca605",
+            "version": "0.4.3"
+        },
+        "TensorMarket": {
+            "uuid": "8b7d4fe7-0b45-4d0d-9dd8-5cc9b23b4b77",
+            "version":"0.2.0"
+        }
+    },
+    "julia": "^1.10"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ packages = [{include = "finch", from = "src"}]
 
 [tool.poetry.dependencies]
 python = "^3.10"
-juliapkg = "^0.1.10"
+juliapkg = "^0.1.16"
 juliacall = "^0.9.15"
 numpy = ">=1.19"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "finch-tensor"
-version = "0.2.4"
+version = "0.2.5"
 description = ""
 authors = ["Willow Ahrens <willow.marie.ahrens@gmail.com>"]
 readme = "README.md"

--- a/src/finch/io.py
+++ b/src/finch/io.py
@@ -1,39 +1,14 @@
 from pathlib import Path
 
-from .julia import add_package, jl
+from .julia import jl
 from .tensor import Tensor
-
-
-def _import_deps(filename: str) -> None:
-    fn = filename
-    if fn.endswith(".mtx") or fn.endswith(".ttx") or fn.endswith(".tns"):
-        add_package(
-            "TensorMarket", hash="8b7d4fe7-0b45-4d0d-9dd8-5cc9b23b4b77", version="0.2.0"
-        )
-        jl.seval("using TensorMarket")
-    elif fn.endswith(".bspnpy"):
-        add_package("NPZ", hash="15e1cf62-19b3-5cfa-8e77-841668bca605", version="0.4.3")
-        jl.seval("using NPZ")
-    elif fn.endswith(".bsp.h5"):
-        add_package(
-            "HDF5", hash="f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f", version="0.17.2"
-        )
-        jl.seval("using HDF5")
-    else:
-        raise ValueError(
-            "Unsupported file extension. Supported extensions are "
-            "`.mtx`, `.ttx`, `.tns`, `.bspnpy`, and `.bsp.h5`."
-        )
-
 
 def read(filename: Path | str) -> Tensor:
     fn = str(filename)
-    _import_deps(fn)
     julia_obj = jl.fread(fn)
     return Tensor(julia_obj)
 
 
 def write(filename: Path | str, tns: Tensor) -> None:
     fn = str(filename)
-    _import_deps(fn)
     jl.fwrite(fn, tns._obj)

--- a/src/finch/julia.py
+++ b/src/finch/julia.py
@@ -7,4 +7,7 @@ import juliacall as jc  # noqa
 from juliacall import Main as jl  # noqa
 
 jl.seval("using Finch")
+jl.seval("using HDF5")
+jl.seval("using NPZ")
+jl.seval("using TensorMarket")
 jl.seval("using Random")

--- a/src/finch/julia.py
+++ b/src/finch/julia.py
@@ -1,36 +1,9 @@
 import os
 
-import juliapkg
-
-
-def add_package(name: str, hash: str, version: str) -> None:
-    deps = juliapkg.deps.load_cur_deps()
-    if deps.get("packages", {}).get(name, {}).get("version", None) != version:
-        juliapkg.add(name, hash, version=version)
-        juliapkg.resolve()
-
-
-_FINCH_NAME = "Finch"
-_FINCH_VERSION = "1.2.0"
-_FINCH_HASH = "9177782c-1635-4eb9-9bfb-d9dfa25e6bce"
-_FINCH_REPO_PATH = os.environ.get("FINCH_REPO_PATH", default=None)
-_FINCH_REPO_URL = os.environ.get("FINCH_URL_PATH", default=None)
-
-if _FINCH_REPO_PATH and _FINCH_REPO_URL:
-    raise ValueError(
-        "FINCH_REPO_PATH and FINCH_URL_PATH can't be set at the same time."
-    )
-
-if _FINCH_REPO_PATH:  # Also account for empty string
-    juliapkg.add(_FINCH_NAME, _FINCH_HASH, path=_FINCH_REPO_PATH, dev=True)
-elif _FINCH_REPO_URL:
-    juliapkg.add(_FINCH_NAME, _FINCH_HASH, url=_FINCH_REPO_URL, dev=True)
-else:
-    add_package(_FINCH_NAME, _FINCH_HASH, _FINCH_VERSION)
-
+#To change the version of Finch used, see the documentation for pyjuliapkg here: https://github.com/JuliaPy/pyjuliapkg
+#Use pyjuliapkg to modify the `juliapkg.json` file in the root of this repo.
+#An example development json is found in `juliapkg_dev.json`
 import juliacall as jc  # noqa
-
-juliapkg.resolve()
 from juliacall import Main as jl  # noqa
 
 jl.seval("using Finch")


### PR DESCRIPTION
This follows the docs for pyjuliapkg a little better. Note the discussion in https://github.com/JuliaPy/pyjuliapkg/pull/45 about why the old behavior was not thread safe. I believe this should work better. I think this should fix https://github.com/pydata/sparse/pull/767 because of the aforementioned fix to pyjuliapkg. This would remove support for envvars that dictate the version of Finch to use, in favor of modifying the juliapkg.json file. I don't think this is that much more or less convenient than the old solution, but it is correct with how the maintainer of pyjuliapkg expected the system to be used.