### PR TITLE
ENH: `linalg` module, `mT` property, and multiple outputs from `@compiled`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       args: ["--autofix", "--no-ensure-ascii"]
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.8.3
+  rev: v0.9.10
   hooks:
     - id: ruff
       args: ["--fix"]

--- a/pixi.toml
+++ b/pixi.toml
@@ -7,6 +7,7 @@ platforms = ["osx-arm64"]
 version = "0.1.0"
 
 [tasks]
+compile = "python -c 'import finch'"
 
 [dependencies]
 python = ">=3.10,<3.13"
@@ -22,9 +23,13 @@ numpy = ">=1.17"
 pytest = "*"
 pytest-cov = "*"
 sparse = "*"
-numba = ">=0.55,<0.60"
+numba = ">=0.60"
 scipy = "*"
+numpy = "==2.*"
 pytest-xdist = ">=3.6.1,<4"
+
+[feature.test.tasks]
+test = { cmd = "pytest", depends-on = ["compile"] }
 
 [environments]
 test = ["test"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "finch-tensor"
-version = "0.2.7"
+version = "0.2.8"
 description = ""
 authors = ["Willow Ahrens <willow.marie.ahrens@gmail.com>"]
 readme = "README.md"

--- a/src/finch/__init__.py
+++ b/src/finch/__init__.py
@@ -141,6 +141,7 @@ from .io import (
     read,
     write,
 )
+from . import linalg
 
 __all__ = [
     "Tensor",
@@ -272,6 +273,7 @@ __all__ = [
     "arange",
     "linspace",
     "set_optimizer",
+    "linalg",
 ]
 
 __array_api_version__: str = "2023.12"

--- a/src/finch/compiled.py
+++ b/src/finch/compiled.py
@@ -50,6 +50,13 @@ def compiled(opt=None, *, force_materialization=False, tag: int | None = None):
             )
             if tag is not None:
                 compute_kwargs["tag"] = tag
+
+            if isinstance(result, Iterable):
+                computed = jl.Finch.compute(
+                    *map(lambda x: x._obj, result), **compute_kwargs
+                )
+                return tuple(Tensor(c) for c in computed)
+
             return Tensor(jl.Finch.compute(result._obj, **compute_kwargs))
 
         return wrapper_func

--- a/src/finch/compiled.py
+++ b/src/finch/compiled.py
@@ -1,5 +1,6 @@
 from abc import abstractmethod
 from functools import wraps
+from dataclasses import dataclass
 
 from .julia import jl
 from .typing import JuliaObj
@@ -13,7 +14,7 @@ def _recurse(x: IterObj, /, *, f: Callable[[Any], Any]) -> IterObj:
     if isinstance(x, tuple | list):
         return type(x)(_recurse(xi, f=f) for xi in x)
     if isinstance(x, dict):
-        ret = {k: _recurse(v, f=f) for k, v in x}
+        ret = {k: _recurse(v, f=f) for k, v in x.items()}
         if type(x) is not dict:
             ret = type(x)(ret)
         return ret
@@ -24,9 +25,11 @@ def _recurse_iter(x: IterObj, /) -> Iterator[Any]:
     if isinstance(x, tuple | list):
         for xi in x:
             yield from _recurse_iter(xi)
+        return
     if isinstance(x, dict):
         for xi in x.values():
             yield from _recurse_iter(xi)
+        return
     yield x
 
 
@@ -34,34 +37,36 @@ def _to_lazy_tensor(x: Tensor | Any, /) -> Tensor | Any:
     return x if not isinstance(x, Tensor) else lazy(x)
 
 
-def _recurse_iter_return(x: IterObj, /, *, compute_kwargs: dict[str, Any]) -> IterObj:
-    current = 0
+@dataclass
+class _ArgumentIndexer:
+    _idx: int = 0
 
-    def recursor(_: Any) -> tuple[int, Any]:
-        nonlocal current
-        ret = current
-        current += 1
+    def index(self, _) -> int:
+        ret = self._idx
+        self._idx += 1
         return ret
 
+
+def _recurse_iter_compute(x: IterObj, /, *, compute_kwargs: dict[str, Any]) -> IterObj:
     # Make a recursive iterator of indices.
-    idx_obj = _recurse(x, f=recursor)
+    idx_obj = _recurse(x, f=_ArgumentIndexer().index)
     jl_computed = []
     py_computed = []
 
     # Collect lazy tensors; use placeholder
     _placeholder = object()
-    for x in _recurse_iter(x):
-        if isinstance(x, Tensor) and not x.is_computed():
-            jl_computed.append(x._obj)
+    for xi in _recurse_iter(x):
+        if isinstance(xi, Tensor) and not xi.is_computed():
+            jl_computed.append(xi._obj)
             py_computed.append(_placeholder)
         else:
-            py_computed.append(x)
-
-    if len(jl_computed) == 1:
-        # This doesn't return an iterable of arrays -- only a single array
-        jl_computed = [jl.Finch.compute(*jl_computed, **compute_kwargs)]
-    else:
-        jl_computed = jl.Finch.compute(*jl_computed, **compute_kwargs)
+            py_computed.append(xi)
+    jl_len = len(jl_computed)
+    # This doesn't return an iterable of arrays -- only a single array
+    # for `len(jl_computed) == 1`
+    jl_computed = jl.Finch.compute(*jl_computed, **compute_kwargs)
+    if jl_len == 1:
+        jl_computed = (jl_computed,)
 
     # Replace placeholders with computed tensors.
     jl_computed_iter = iter(jl_computed)
@@ -95,7 +100,7 @@ def compiled(opt=None, *, force_materialization=False, tag: int | None = None):
             if tag is not None:
                 compute_kwargs["tag"] = tag
 
-            return _recurse_iter_return(result, compute_kwargs=compute_kwargs)
+            return _recurse_iter_compute(result, compute_kwargs=compute_kwargs)
 
         return wrapper_func
 

--- a/src/finch/levels.py
+++ b/src/finch/levels.py
@@ -1,8 +1,10 @@
 from .julia import jl
-from .typing import OrderType, DType
+from .typing import OrderType, DType, JuliaObj
 
 
 class _Display:
+    _obj: JuliaObj
+
     def __repr__(self):
         return jl.sprint(jl.show, self._obj)
 

--- a/src/finch/linalg/__init__.py
+++ b/src/finch/linalg/__init__.py
@@ -1,0 +1,3 @@
+from ._linalg import vector_norm
+
+__all__ = ["vector_norm"]

--- a/src/finch/linalg/_linalg.py
+++ b/src/finch/linalg/_linalg.py
@@ -1,0 +1,22 @@
+from ..julia import jl
+from ..tensor import Tensor
+
+
+def vector_norm(
+    x: Tensor,
+    /,
+    *,
+    axis: int | tuple[int, ...] | None = None,
+    keepdims: bool = False,
+    ord: int | float = 2,
+) -> Tensor:
+    if axis is not None:
+        raise ValueError(
+            "At the moment only `None` (vector norm of a flattened array) "
+            "is supported. Got: {axis}."
+        )
+
+    result = Tensor(jl.Finch.norm(x._obj, ord))
+    if keepdims:
+        result = result.__getitem__(tuple(None for _ in range(x.ndim)))
+    return result

--- a/src/finch/linalg/_linalg.py
+++ b/src/finch/linalg/_linalg.py
@@ -1,3 +1,5 @@
+from numpy.core.numeric import normalize_axis_tuple
+
 from ..julia import jl
 from ..tensor import Tensor
 
@@ -11,12 +13,14 @@ def vector_norm(
     ord: int | float = 2,
 ) -> Tensor:
     if axis is not None:
-        raise ValueError(
-            "At the moment only `None` (vector norm of a flattened array) "
-            "is supported. Got: {axis}."
-        )
+        axis = normalize_axis_tuple(axis, x.ndim)
+        if axis != tuple(range(x.ndim)):
+            raise ValueError(
+                "At the moment only `None` (vector norm of a flattened array) "
+                "is supported. Got: {axis}."
+            )
 
     result = Tensor(jl.Finch.norm(x._obj, ord))
     if keepdims:
-        result = result.__getitem__(tuple(None for _ in range(x.ndim)))
+        result = result[tuple(None for _ in range(x.ndim))]
     return result

--- a/src/finch/tensor.py
+++ b/src/finch/tensor.py
@@ -296,6 +296,13 @@ class Tensor(_Display, SparseArray):
         return jl.typeof(self._obj).parameters[1]
 
     @property
+    def mT(self) -> "Tensor":
+        axes = list(range(self.ndim))
+        axes[-2:] = axes[:-3:-1]
+        axes = tuple(axes)
+        return self.permute_dims(axes)
+
+    @property
     def device(self) -> str:
         return "cpu"
 

--- a/src/finch/tensor.py
+++ b/src/finch/tensor.py
@@ -298,7 +298,7 @@ class Tensor(_Display, SparseArray):
     @property
     def mT(self) -> "Tensor":
         axes = list(range(self.ndim))
-        axes[-2:] = axes[:-3:-1]
+        axes[-2], axes[-1] = axes[-1], axes[-2]
         axes = tuple(axes)
         return self.permute_dims(axes)
 

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -1,0 +1,35 @@
+import finch
+import numpy as np
+from numpy.testing import assert_allclose
+import pytest
+
+
+arr1d = np.array([1, -1, 2, 3])
+arr2d = np.array([[1, 2, 0, 4, 0], [0, -2, 1, 0, 1]])
+
+
+@pytest.mark.parametrize("arr", [arr1d, arr2d])
+@pytest.mark.parametrize("keepdims", [True, False])
+@pytest.mark.parametrize(
+    "ord",
+    [
+        0,
+        1,
+        10,
+        finch.inf,
+        -finch.inf,
+        pytest.param(
+            2,
+            marks=pytest.mark.skip(
+                reason="https://github.com/finch-tensor/Finch.jl/pull/709"
+            ),
+        ),
+    ],
+)
+def test_vector_norm(arr, keepdims, ord):
+    tns = finch.asarray(arr)
+
+    actual = finch.linalg.vector_norm(tns, keepdims=keepdims, ord=ord)
+    expected = np.linalg.vector_norm(arr, keepdims=keepdims, ord=ord)
+
+    assert_allclose(actual.todense(), expected)

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -55,6 +55,24 @@ def test_lazy_mode(arr3d, opt):
     assert_equal(result.todense(), np.multiply(arr3d, arr2d))
 
 
+def test_lazy_mode_mult_output(opt):
+    A_finch = finch.Tensor(arr1d)
+    B_finch = finch.Tensor(arr2d)
+
+    @finch.compiled(opt=opt)
+    def mult_out_fun(arr1, arr2):
+        out1 = finch.add(arr1, arr2)
+        out2 = finch.multiply(arr1, arr2)
+        out3 = arr2**finch.asarray(2)
+        return out1, out2, out3
+
+    res1, res2, res3 = mult_out_fun(A_finch, B_finch)
+
+    assert_equal(res1.todense(), np.add(arr1d, arr2d))
+    assert_equal(res2.todense(), np.multiply(arr1d, arr2d))
+    assert_equal(res3.todense(), arr2d**2)
+
+
 @pytest.mark.parametrize(
     "func_name",
     [

--- a/tests/test_sparse.py
+++ b/tests/test_sparse.py
@@ -149,6 +149,14 @@ def test_permute_dims(arr3d, permutation, order, opt):
     assert_equal(actual_eager_mode.todense(), expected)
     assert_equal(actual_lazy_mode.todense(), expected)
 
+    # test `.mT`
+    actual_eager_mode = arr_finch.mT
+    actual_lazy_mode = finch.compute(finch.lazy(arr_finch).mT)
+    expected = arr.mT
+
+    assert_equal(actual_eager_mode.todense(), expected)
+    assert_equal(actual_lazy_mode.todense(), expected)
+
 
 @pytest.mark.parametrize("order", ["C", "F"])
 @parametrize_optimizer


### PR DESCRIPTION
Hi @hameerabbasi,

This PR introduces improvements that my `pydata/sparse` use-case requires:
- Array API compatible `linalg` module with the first function, `vector_norm`.
- Array API `mT` array class property.
- `@compiled` decorator accepting multiple outputs.
