### PR TITLE
0.2.9 release

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -4,7 +4,7 @@ channels = ["conda-forge"]
 description = "Add a short description here"
 name = "finch-tensor"
 platforms = ["osx-arm64"]
-version = "0.1.0"
+version = "0.2.9"
 
 [tasks]
 compile = "python -c 'import finch'"
@@ -15,9 +15,9 @@ juliaup = ">=1.17.10,<2"
 
 [pypi-dependencies]
 finch-tensor = { path = ".", editable = true }
-juliapkg = ">=0.1.15,<0.2"
+juliapkg = ">=0.1.16,<0.2"
 juliacall = ">=0.9.23,<0.10"
-numpy = ">=1.17"
+numpy = ">=1.19"
 
 [feature.test.pypi-dependencies]
 pytest = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "finch-tensor"
-version = "0.2.8"
+version = "0.2.9"
 description = ""
 authors = ["Willow Ahrens <willow.marie.ahrens@gmail.com>"]
 readme = "README.md"
@@ -9,7 +9,7 @@ packages = [{include = "finch", from = "src"}]
 [tool.poetry.dependencies]
 python = "^3.10"
 juliapkg = "^0.1.16"
-juliacall = "^0.9.15"
+juliacall = "^0.9.23"
 numpy = ">=1.19"
 
 [tool.poetry.group.test.dependencies]

--- a/src/finch/juliapkg.json
+++ b/src/finch/juliapkg.json
@@ -2,7 +2,7 @@
     "packages": {
         "Finch": {
             "uuid": "9177782c-1635-4eb9-9bfb-d9dfa25e6bce",
-            "version": "1.2.1"
+            "version": "1.2.2"
         },
         "HDF5": {
             "uuid": "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f",


### PR DESCRIPTION
Hi @hameerabbasi,

Here's a new release with latest Finch.jl version.

Should we keep `pyproject.toml` and `pixi.toml` aligned? I think keeping all dependencies' versions the same avoids confusion.
Do we need both `pyproject.toml` and `pixi.toml`? Can pixi use `pyproject`?
Do we need `poetry.lock` in the repo?
