### PR TITLE
MAINT: Expand `reshape` testing

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -4,7 +4,7 @@ channels = ["conda-forge"]
 description = "Add a short description here"
 name = "finch-tensor"
 platforms = ["osx-arm64"]
-version = "0.2.10"
+version = "0.2.12"
 
 [tasks]
 compile = "python -c 'import finch'"
@@ -16,14 +16,14 @@ juliaup = ">=1.17.10,<2"
 [pypi-dependencies]
 finch-tensor = { path = ".", editable = true }
 juliapkg = ">=0.1.16,<0.2"
-juliacall = ">=0.9.23,<0.10"
+juliacall = ">=0.9.24,<0.10"
 numpy = ">=1.19"
 
 [feature.test.pypi-dependencies]
 pytest = "*"
 pytest-cov = "*"
-sparse = "*"
-numba = ">=0.60"
+sparse = ">=0.16,<0.17"
+numba = ">=0.61"
 scipy = "*"
 numpy = "==2.*"
 pytest-xdist = ">=3.6.1,<4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "finch-tensor"
-version = "0.2.11"
+version = "0.2.12"
 description = ""
 authors = ["Willow Ahrens <willow.marie.ahrens@gmail.com>"]
 readme = "README.md"
@@ -10,7 +10,10 @@ packages = [{include = "finch", from = "src"}]
 python = "^3.10"
 juliapkg = "^0.1.16"
 numpy = ">=1.19"
-juliacall = "^0.9.24"
+juliacall = [
+    { version = "0.9.24", platform = "darwin" },
+    { version = "^0.9.24" }
+]
 
 [tool.poetry.group.test.dependencies]
 pytest = "^7.4.4"

--- a/src/finch/juliapkg.json
+++ b/src/finch/juliapkg.json
@@ -2,7 +2,7 @@
     "packages": {
         "Finch": {
             "uuid": "9177782c-1635-4eb9-9bfb-d9dfa25e6bce",
-            "version": "1.2.7"
+            "version": "1.2.9"
         },
         "HDF5": {
             "uuid": "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f",

--- a/tests/test_sparse.py
+++ b/tests/test_sparse.py
@@ -249,7 +249,11 @@ def test_asarray(arr2d, arr3d, order, format, opt):
         (np.ones((10, 10)), (100,)),
         (np.ones((3, 4, 5)), (5, 2, 2, 3)),
         (np.arange(1), (1, 1, 1, 1)),
+        (np.arange(1).reshape((1, 1, 1)), (1,)),
+        (np.arange(1).reshape((1, 1)), ()),
         (np.zeros((10, 1, 2)), (1, 5, 4, 1)),
+        (np.int64(0), ()),
+        (np.int64(0), (1, 1)),
     ],
 )
 @pytest.mark.parametrize("order", ["C", "F"])


### PR DESCRIPTION
New version of `finch-tensor` without a performance regression. 